### PR TITLE
Implement lang.reflection.Methods::annotated($annotation)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,8 +3,8 @@ XP Reflection ChangeLog
 
 ## ?.?.? / ????-??-??
 
-* Added `lang.reflect.Methods::with()` method to enumerate all methods
-  with a given annotation
+* Added `lang.reflect.Methods::annotated()` method to enumerate all
+  methods with a given annotation
   (@thekid)
 * Fixed accessing meta data for type members via `xp::$meta` cache
   (@thekid)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@ XP Reflection ChangeLog
 
 ## ?.?.? / ????-??-??
 
+## 0.6.0 / 2020-12-19
+
 * Added `lang.reflect.Methods::annotated()` method to enumerate all
   methods with a given annotation
   (@thekid)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,9 @@ XP Reflection ChangeLog
 
 ## ?.?.? / ????-??-??
 
+* Added `lang.reflect.Methods::with()` method to enumerate all methods
+  with a given annotation
+  (@thekid)
 * Fixed accessing meta data for type members via `xp::$meta` cache
   (@thekid)
 

--- a/src/main/php/lang/reflection/Member.class.php
+++ b/src/main/php/lang/reflection/Member.class.php
@@ -6,9 +6,9 @@ abstract class Member implements Value {
   protected $reflect, $meta;
 
   /** @param ReflectionClass|ReflectionProperty|ReflectionClassConstant $reflect */
-  public function __construct($reflect, $annotations= null) {
+  public function __construct($reflect, $meta= null) {
     $this->reflect= $reflect;
-    $this->annotations= $annotations;
+    $this->meta= $meta;
   }
 
   /**

--- a/src/main/php/lang/reflection/Member.class.php
+++ b/src/main/php/lang/reflection/Member.class.php
@@ -2,10 +2,17 @@
 
 use lang\{XPClass, Reflection, Value};
 
+/** Base class for constants, properties and methods */
 abstract class Member implements Value {
   protected $reflect, $meta;
 
-  /** @param ReflectionClass|ReflectionProperty|ReflectionClassConstant $reflect */
+  /**
+   * Creates a new member from a PHP reflection class, optionally passing
+   * pre-parsed meta information so that it won't need to be parsed again.
+   *
+   * @param  ReflectionClass|ReflectionProperty|ReflectionClassConstant $reflect
+   * @param  ?[:var] $meta 
+   */
   public function __construct($reflect, $meta= null) {
     $this->reflect= $reflect;
     $this->meta= $meta;

--- a/src/main/php/lang/reflection/Member.class.php
+++ b/src/main/php/lang/reflection/Member.class.php
@@ -6,8 +6,9 @@ abstract class Member implements Value {
   protected $reflect, $annotations;
 
   /** @param ReflectionClass|ReflectionProperty|ReflectionClassConstant $reflect */
-  public function __construct($reflect) {
+  public function __construct($reflect, $annotations= null) {
     $this->reflect= $reflect;
+    $this->annotations= $annotations;
   }
 
   /**

--- a/src/main/php/lang/reflection/Methods.class.php
+++ b/src/main/php/lang/reflection/Methods.class.php
@@ -12,12 +12,12 @@ class Methods extends Members {
   }
 
   /**
-   * Return methods with a given annotation
+   * Return methods annotated with a given annotation
    *
    * @param  string $annotation
    * @return iterable
    */
-  public function with($annotation) {
+  public function annotated($annotation) {
     $t= strtr($annotation, '.', '\\');
     foreach ($this->reflect->getMethods() as $method) {
       if (0 !== strncmp($method->name, '__', 2)) {

--- a/src/main/php/lang/reflection/Methods.class.php
+++ b/src/main/php/lang/reflection/Methods.class.php
@@ -21,8 +21,8 @@ class Methods extends Members {
     $t= strtr($annotation, '.', '\\');
     foreach ($this->reflect->getMethods() as $method) {
       if (0 !== strncmp($method->name, '__', 2)) {
-        $annotations= Reflection::meta()->ofMethod($method);
-        if (isset($annotations[$t])) yield $method->name => new Method($method, $annotations);
+        $meta= Reflection::meta()->ofMethod($method);
+        if (isset($meta[DETAIL_ANNOTATIONS][$t])) yield $method->name => new Method($method, $meta);
       }
     }
   }

--- a/src/main/php/lang/reflection/Methods.class.php
+++ b/src/main/php/lang/reflection/Methods.class.php
@@ -1,12 +1,28 @@
 <?php namespace lang\reflection;
 
+use lang\Reflection;
+
 class Methods extends Members {
 
   /** @return iterable */
   public function getIterator() {
     foreach ($this->reflect->getMethods() as $method) {
+      if (0 !== strncmp($method->name, '__', 2)) yield $method->name => new Method($method);
+    }
+  }
+
+  /**
+   * Return methods with a given annotation
+   *
+   * @param  string $annotation
+   * @return iterable
+   */
+  public function with($annotation) {
+    $t= strtr($annotation, '.', '\\');
+    foreach ($this->reflect->getMethods() as $method) {
       if (0 !== strncmp($method->name, '__', 2)) {
-        yield $method->name => new Method($method);
+        $annotations= Reflection::meta()->ofMethod($method);
+        if (isset($annotations[$t])) yield $method->name => new Method($method, $annotations);
       }
     }
   }

--- a/src/test/php/lang/reflection/unittest/MethodsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/MethodsTest.class.php
@@ -54,7 +54,7 @@ class MethodsTest {
   }
 
   #[Test]
-  public function with() {
+  public function annotated() {
     $type= $this->declare('{
       #[Annotated]
       public function a() { }
@@ -67,7 +67,7 @@ class MethodsTest {
 
     Assert::equals(
       ['a' => $type->method('a'), 'b' => $type->method('b')],
-      iterator_to_array($type->methods()->with(Annotated::class))
+      iterator_to_array($type->methods()->annotated(Annotated::class))
     );
   }
 

--- a/src/test/php/lang/reflection/unittest/MethodsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/MethodsTest.class.php
@@ -54,6 +54,24 @@ class MethodsTest {
   }
 
   #[Test]
+  public function with() {
+    $type= $this->declare('{
+      #[Annotated]
+      public function a() { }
+
+      #[Annotated]
+      public function b() { }
+
+      public function c() { }
+    }');
+
+    Assert::equals(
+      ['a' => $type->method('a'), 'b' => $type->method('b')],
+      iterator_to_array($type->methods()->with(Annotated::class))
+    );
+  }
+
+  #[Test]
   public function non_existant() {
     $type= $this->declare('{ }');
     Assert::null($type->methods()->named('fixture'));


### PR DESCRIPTION
This method returns all methods with a given annotation, making code like this more concise:

```php
// Before
foreach ($type->methods() as $m) {
  if ($m->annotation(BeforeClass::class)) yield $m->invoke(null);
}

// After
foreach ($type->methods()->annotated(BeforeClass::class) as $m) {
  yield $m->invoke(null);
}
```