### PR TITLE
Refactor: Use meta information

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ foreach ($type->properties() as $name => $property) {
   $property->annotations();                // Annotations
   $property->annotation(Inject::class);    // Annotation or NULL
   $property->declaredIn();                 // Type
+  $property->constraint();                 // TypeHint
   $property->get($instance);               // (property value)
   $property->set($instance, $value);       // (value)
 }

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ foreach ($type->properties() as $name => $property) {
   $property->annotations();                // Annotations
   $property->annotation(Inject::class);    // Annotation or NULL
   $property->declaredIn();                 // Type
-  $property->constraint();                 // TypeHint
+  $property->constraint();                 // Constraint
   $property->get($instance);               // (property value)
   $property->set($instance, $value);       // (value)
 }
@@ -101,7 +101,7 @@ foreach ($type->methods() as $name => $method) {
   $method->annotations();                  // Annotations
   $method->annotation(Inject::class);      // Annotation or NULL
   $method->declaredIn();                   // Type
-  $method->returns();                      // TypeHint
+  $method->returns();                      // Constraint
   $method->parameters();                   // Parameters
   $method->parameter(0);                   // Parameter or NULL
   $method->closure($instance);             // Closure instance
@@ -121,7 +121,7 @@ foreach ($method->parameters() as $name => $parameter) {
   $parameter->variadic();                 // false
   $parameter->optional();                 // true
   $parameter->default();                  // (parameter default value)
-  $parameter->constraint();               // TypeHint
+  $parameter->constraint();               // Constraint
   $parameter->annotations();              // Annotations
   $parameter->annotation(Inject::class)   // Annotation or NULL
 }

--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -31,29 +31,41 @@ class MetaInformation {
 
   /** @return iterable */
   public function ofType($reflect) {
-    $meta= \xp::$meta[strtr($reflect->name, '\\', '.')]['class'] ?? null;
-    return $meta ? $this->annotations($meta) : $this->delegate->ofType($reflect);
+    if ($meta= \xp::$meta[strtr($reflect->name, '\\', '.')]['class'] ?? null) {
+      return [DETAIL_ANNOTATIONS => $this->annotations($meta)];
+    }
+
+    return [DETAIL_ANNOTATIONS => $this->delegate->ofType($reflect)];
   }
 
   /** @return iterable */
   public function ofConstant($reflect) {
     $c= strtr($reflect->getDeclaringClass()->name, '\\', '.');
-    $meta= \xp::$meta[$c][2][$reflect->name] ?? null;
-    return $meta ? $this->annotations($meta) : $this->delegate->ofConstant($reflect);
+    if ($meta= \xp::$meta[$c][2][$reflect->name] ?? null) {
+      return [DETAIL_ANNOTATIONS => $this->annotations($meta)];
+    }
+
+    return [DETAIL_ANNOTATIONS => $this->delegate->ofConstant($reflect)];
   }
 
   /** @return iterable */
   public function ofProperty($reflect) {
     $c= strtr($reflect->getDeclaringClass()->name, '\\', '.');
-    $meta= \xp::$meta[$c][0][$reflect->name] ?? null;
-    return $meta ? $this->annotations($meta) : $this->delegate->ofProperty($reflect);
+    if ($meta= \xp::$meta[$c][0][$reflect->name] ?? null) {
+      return [DETAIL_ANNOTATIONS => $this->annotations($meta)];
+    }
+
+    return [DETAIL_ANNOTATIONS => $this->delegate->ofProperty($reflect)];
   }
 
   /** @return iterable */
   public function ofMethod($reflect) {
     $c= strtr($reflect->getDeclaringClass()->name, '\\', '.');
-    $meta= \xp::$meta[$c][1][$reflect->name] ?? null;
-    return $meta ? $this->annotations($meta) : $this->delegate->ofMethod($reflect);
+    if ($meta= \xp::$meta[$c][1][$reflect->name] ?? null) {
+      return [DETAIL_ANNOTATIONS => $this->annotations($meta)];
+    }
+
+    return [DETAIL_ANNOTATIONS => $this->delegate->ofMethod($reflect)];
   }
 
   /** @return iterable */

--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -62,7 +62,7 @@ class MetaInformation {
   public function ofMethod($reflect) {
     $c= strtr($reflect->getDeclaringClass()->name, '\\', '.');
     if ($meta= \xp::$meta[$c][1][$reflect->name] ?? null) {
-      return [DETAIL_ANNOTATIONS => $this->annotations($meta)];
+      return [DETAIL_ANNOTATIONS => $this->annotations($meta), DETAIL_RETURNS => $meta[DETAIL_RETURNS]];
     }
 
     return [DETAIL_ANNOTATIONS => $this->delegate->ofMethod($reflect)];
@@ -71,15 +71,15 @@ class MetaInformation {
   /** @return iterable */
   public function ofParameter($method, $reflect) {
     $c= strtr($method->getDeclaringClass()->name, '\\', '.');
-    if ($target= \xp::$meta[$c][1][$method->name][DETAIL_TARGET_ANNO] ?? null) {
-      if ($meta= $target['$'.$reflect->name] ?? null) {
+    if ($meta= \xp::$meta[$c][1][$method->name] ?? null) {
+      if ($param= $meta[DETAIL_TARGET_ANNO]['$'.$reflect->name] ?? null) {
         $r= [];
-        foreach ($meta as $name => $value) {
-          $r[$target[$name] ?? $name]= (array)$value;
+        foreach ($param as $name => $value) {
+          $r[$meta[DETAIL_TARGET_ANNO][$name] ?? $name]= (array)$value;
         }
-        return $r;
+        return [DETAIL_ANNOTATIONS => $r, DETAIL_RETURNS => $meta[DETAIL_ARGUMENTS][$reflect->getPosition()]];
       }
     }
-    return $this->delegate->ofParameter($method, $reflect);
+    return [DETAIL_ANNOTATIONS => $this->delegate->ofParameter($method, $reflect)];
   }
 }

--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -30,7 +30,7 @@ class MetaInformation {
   }
 
   public function tags($reflect) {
-    preg_match_all('/@(return|param)\s+(.+)/', $reflect->getDocComment(), $matches, PREG_SET_ORDER);
+    preg_match_all('/@([a-z]+)\s+(.+)/', $reflect->getDocComment(), $matches, PREG_SET_ORDER);
     $tags= [];
     foreach ($matches as $match) {
       $tags[$match[1]][]= rtrim($match[2], ' */');
@@ -64,7 +64,10 @@ class MetaInformation {
       return [DETAIL_ANNOTATIONS => $this->annotations($meta), DETAIL_RETURNS => $meta[DETAIL_RETURNS]];
     }
 
-    return [DETAIL_ANNOTATIONS => $this->annotations->ofProperty($reflect)];
+    return [
+      DETAIL_ANNOTATIONS => $this->annotations->ofProperty($reflect),
+      DETAIL_RETURNS     => $this->tags($reflect)['type'][0] ?? null
+    ];
   }
 
   /** @return iterable */

--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -15,15 +15,6 @@ class MetaInformation {
     return $this->annotations->evaluate($reflect, $code);
   }
 
-  private function tags($reflect) {
-    preg_match_all('/@(return|param)\s+(.+)/', $reflect->getDocComment(), $matches, PREG_SET_ORDER);
-    $tags= [];
-    foreach ($matches as $match) {
-      $tags[$match[1]][]= rtrim($match[2], ' */');
-    }
-    return $tags;
-  }
-
   /**
    * Constructs annotations from meta information
    *
@@ -36,6 +27,15 @@ class MetaInformation {
       $r[$meta[DETAIL_TARGET_ANNO][$name] ?? $name]= (array)$value;
     }
     return $r;
+  }
+
+  public function tags($reflect) {
+    preg_match_all('/@(return|param)\s+(.+)/', $reflect->getDocComment(), $matches, PREG_SET_ORDER);
+    $tags= [];
+    foreach ($matches as $match) {
+      $tags[$match[1]][]= rtrim($match[2], ' */');
+    }
+    return $tags;
   }
 
   /** @return iterable */
@@ -95,13 +95,13 @@ class MetaInformation {
 
     if ($tag= $this->tags($method)['param'][$reflect->getPosition()] ?? null) {
       preg_match('/([^ ]+)( \$?[a-z_]+)/i', $tag, $matches);
-      $returns= $matches[1];
+      $type= $matches[1];
     } else {
-      $returns= null;
+      $type= null;
     }
     return [
       DETAIL_ANNOTATIONS => $this->annotations->ofParameter($method, $reflect),
-      DETAIL_RETURNS     => $returns
+      DETAIL_RETURNS     => $type
     ];
   }
 }

--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -52,7 +52,7 @@ class MetaInformation {
   public function ofProperty($reflect) {
     $c= strtr($reflect->getDeclaringClass()->name, '\\', '.');
     if ($meta= \xp::$meta[$c][0][$reflect->name] ?? null) {
-      return [DETAIL_ANNOTATIONS => $this->annotations($meta)];
+      return [DETAIL_ANNOTATIONS => $this->annotations($meta), DETAIL_RETURNS => $meta[DETAIL_RETURNS]];
     }
 
     return [DETAIL_ANNOTATIONS => $this->delegate->ofProperty($reflect)];

--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -5,14 +5,14 @@
  * it to another source otherwise.
  */
 class MetaInformation {
-  public $delegate;
+  private $annotations;
 
-  public function __construct($delegate) {
-    $this->delegate= $delegate;
+  public function __construct($annotations) {
+    $this->annotations= $annotations;
   }
 
   public function evaluate($reflect, $code) {
-    return $this->delegate->evaluate($reflect, $code);
+    return $this->annotations->evaluate($reflect, $code);
   }
 
   /**
@@ -35,7 +35,7 @@ class MetaInformation {
       return [DETAIL_ANNOTATIONS => $this->annotations($meta)];
     }
 
-    return [DETAIL_ANNOTATIONS => $this->delegate->ofType($reflect)];
+    return [DETAIL_ANNOTATIONS => $this->annotations->ofType($reflect)];
   }
 
   /** @return iterable */
@@ -45,7 +45,7 @@ class MetaInformation {
       return [DETAIL_ANNOTATIONS => $this->annotations($meta)];
     }
 
-    return [DETAIL_ANNOTATIONS => $this->delegate->ofConstant($reflect)];
+    return [DETAIL_ANNOTATIONS => $this->annotations->ofConstant($reflect)];
   }
 
   /** @return iterable */
@@ -55,7 +55,7 @@ class MetaInformation {
       return [DETAIL_ANNOTATIONS => $this->annotations($meta), DETAIL_RETURNS => $meta[DETAIL_RETURNS]];
     }
 
-    return [DETAIL_ANNOTATIONS => $this->delegate->ofProperty($reflect)];
+    return [DETAIL_ANNOTATIONS => $this->annotations->ofProperty($reflect)];
   }
 
   /** @return iterable */
@@ -65,7 +65,7 @@ class MetaInformation {
       return [DETAIL_ANNOTATIONS => $this->annotations($meta), DETAIL_RETURNS => $meta[DETAIL_RETURNS]];
     }
 
-    return [DETAIL_ANNOTATIONS => $this->delegate->ofMethod($reflect)];
+    return [DETAIL_ANNOTATIONS => $this->annotations->ofMethod($reflect)];
   }
 
   /** @return iterable */
@@ -80,6 +80,6 @@ class MetaInformation {
         return [DETAIL_ANNOTATIONS => $r, DETAIL_RETURNS => $meta[DETAIL_ARGUMENTS][$reflect->getPosition()]];
       }
     }
-    return [DETAIL_ANNOTATIONS => $this->delegate->ofParameter($method, $reflect)];
+    return [DETAIL_ANNOTATIONS => $this->annotations->ofParameter($method, $reflect)];
   }
 }

--- a/src/main/php/lang/reflection/Constant.class.php
+++ b/src/main/php/lang/reflection/Constant.class.php
@@ -5,7 +5,7 @@ use util\Objects;
 
 class Constant extends Member {
 
-  protected function getAnnotations() { return Reflection::meta()->ofConstant($this->reflect); }
+  protected function meta() { return Reflection::meta()->ofConstant($this->reflect); }
 
   /** Returns a compound name consisting of `[CLASS]::$[NAME]`  */
   public function compoundName(): string { return strtr($this->reflect->class, '\\', '.').'::'.$this->reflect->name; }

--- a/src/main/php/lang/reflection/Constraint.class.php
+++ b/src/main/php/lang/reflection/Constraint.class.php
@@ -2,7 +2,7 @@
 
 use lang\Type;
 
-class TypeHint {
+class Constraint {
   private $type, $present;
 
   public function __construct(Type $type, bool $present= true) {

--- a/src/main/php/lang/reflection/Constructor.class.php
+++ b/src/main/php/lang/reflection/Constructor.class.php
@@ -13,13 +13,7 @@ class Constructor extends Routine {
 
   /** @return string */
   public function toString() {
-
-    // Parse apidoc. FIXME!
-    preg_match_all('/@(param)\s+(.+)/', $this->reflect->getDocComment(), $matches, PREG_SET_ORDER);
-    $tags= [];
-    foreach ($matches as $match) {
-      $tags[$match[1]][]= $match[2];
-    }
+    $tags= Reflection::meta()->tags($this->reflect);
 
     // Compile signature
     $sig= '';

--- a/src/main/php/lang/reflection/Member.class.php
+++ b/src/main/php/lang/reflection/Member.class.php
@@ -3,7 +3,7 @@
 use lang\{XPClass, Reflection, Value};
 
 abstract class Member implements Value {
-  protected $reflect, $annotations;
+  protected $reflect, $meta;
 
   /** @param ReflectionClass|ReflectionProperty|ReflectionClassConstant $reflect */
   public function __construct($reflect) {
@@ -24,20 +24,23 @@ abstract class Member implements Value {
   }
 
   /** @return [:var] */
-  protected abstract function getAnnotations();
+  protected abstract function meta();
 
   /** @return lang.reflection.Annotations */
   public function annotations() {
-    $this->annotations ?? $this->annotations= $this->getAnnotations();
-    return new Annotations($this->annotations);
+    $this->meta ?? $this->meta= $this->meta();
+    return new Annotations($this->meta[DETAIL_ANNOTATIONS]);
   }
 
   /** @return ?lang.reflection.Annotation */
   public function annotation(string $type) {
-    $this->annotations ?? $this->annotations= $this->getAnnotations();
+    $this->meta ?? $this->meta= $this->meta();
 
     $t= strtr($type, '.', '\\');
-    return isset($this->annotations[$t]) ? new Annotation($t, $this->annotations[$t]) : null;
+    return isset($this->meta[DETAIL_ANNOTATIONS][$t])
+      ? new Annotation($t, $this->meta[DETAIL_ANNOTATIONS][$t])
+      : null
+    ;
   }
 
   /** Returns this member's name */

--- a/src/main/php/lang/reflection/Method.class.php
+++ b/src/main/php/lang/reflection/Method.class.php
@@ -83,13 +83,7 @@ class Method extends Routine {
 
   /** @return string */
   public function toString() {
-
-    // Parse apidoc. FIXME!
-    preg_match_all('/@(return|param)\s+(.+)/', $this->reflect->getDocComment(), $matches, PREG_SET_ORDER);
-    $tags= [];
-    foreach ($matches as $match) {
-      $tags[$match[1]][]= $match[2];
-    }
+    $tags= Reflection::meta()->tags($this->reflect);
 
     // Compile signature
     $sig= '';

--- a/src/main/php/lang/reflection/Method.class.php
+++ b/src/main/php/lang/reflection/Method.class.php
@@ -48,7 +48,7 @@ class Method extends Routine {
     if (null === $t) {
       $present= false;
 
-      // Check for type in api documentation, defaulting to `var`
+      // Check for type in meta information, defaulting to `var`
       $t= Type::$VAR;
     } else if ($t instanceof \ReflectionUnionType) {
       $union= [];
@@ -60,7 +60,7 @@ class Method extends Routine {
       $name= PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString();
 
       // Check array, self and callable for more specific types, e.g. `string[]`,
-      // `static` or `function(): string` in api documentation
+      // `static` or `function(): string` in meta information
       if ('array' === $name) {
         $t= Type::$ARRAY;
       } else if ('callable' === $name) {
@@ -73,15 +73,10 @@ class Method extends Routine {
       $present= true;
     }
 
-    // Parse apidoc. FIXME!
-    preg_match_all('/@(return|param)\s+(.+)/', $this->reflect->getDocComment(), $matches, PREG_SET_ORDER);
-    $tags= [];
-    foreach ($matches as $match) {
-      $tags[$match[1]][]= rtrim($match[2], ' */');
-    }
-
+    // Use meta information
+    $this->meta ?? $this->meta= $this->meta();
     return new TypeHint(
-      isset($tags['return'])? Type::resolve($tags['return'][0], $this->resolver()) : $t,
+      isset($this->meta[DETAIL_RETURNS]) ? Type::resolve($this->meta[DETAIL_RETURNS], $this->resolver()) : $t,
       $present
     );
   }

--- a/src/main/php/lang/reflection/Method.class.php
+++ b/src/main/php/lang/reflection/Method.class.php
@@ -42,7 +42,7 @@ class Method extends Routine {
     }
   }
 
-  /** @return lang.reflection.TypeHint */
+  /** @return lang.reflection.Constraint */
   public function returns() {
     $t= $this->reflect->getReturnType();
     if (null === $t) {
@@ -55,7 +55,7 @@ class Method extends Routine {
       foreach ($t->getTypes() as $component) {
         $union[]= Type::resolve($component->getName(), $this->resolver());
       }
-      return new TypeHint(new TypeUnion($union));
+      return new Constraint(new TypeUnion($union));
     } else {
       $name= PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString();
 
@@ -68,14 +68,14 @@ class Method extends Routine {
       } else if ('self' === $name) {
         $t= new XPClass($this->reflect->getDeclaringClass());
       } else {
-        return new TypeHint(Type::resolve($name, $this->resolver()));
+        return new Constraint(Type::resolve($name, $this->resolver()));
       }
       $present= true;
     }
 
     // Use meta information
     $this->meta ?? $this->meta= $this->meta();
-    return new TypeHint(
+    return new Constraint(
       isset($this->meta[DETAIL_RETURNS]) ? Type::resolve($this->meta[DETAIL_RETURNS], $this->resolver()) : $t,
       $present
     );

--- a/src/main/php/lang/reflection/Parameter.class.php
+++ b/src/main/php/lang/reflection/Parameter.class.php
@@ -96,19 +96,10 @@ class Parameter {
       $present= true;
     }
 
-    // Parse apidoc. FIXME!
-    preg_match_all('/@(return|param)\s+(.+)/', $this->method->getDocComment(), $matches, PREG_SET_ORDER);
-    $tags= [];
-    foreach ($matches as $match) {
-      $tags[$match[1]][]= rtrim($match[2], ' */');
-    }
-
-    $p= $this->reflect->getPosition();
-    if (isset($tags['param'][$p])) {
-      preg_match('/([^ ]+)( \$?[a-z_]+)/i', $tags['param'][$p], $matches);
-      return new TypeHint(Type::resolve($matches[1], $this->resolver()), $present);
-    }
-
-    return new TypeHint($t, $present);
+    $this->meta ?? $this->meta= Reflection::meta()->ofParameter($this->method, $this->reflect);
+    return new TypeHint(
+      isset($this->meta[DETAIL_RETURNS]) ? Type::resolve($this->meta[DETAIL_RETURNS], $this->resolver()) : $t,
+      $present
+    );
   }
 }

--- a/src/main/php/lang/reflection/Parameter.class.php
+++ b/src/main/php/lang/reflection/Parameter.class.php
@@ -65,7 +65,7 @@ class Parameter {
     ];
   }
 
-  /** @return lang.reflection.TypeHint */
+  /** @return lang.reflection.Constraint */
   public function constraint() {
     $t= $this->reflect->getType();
     if (null === $t) {
@@ -78,7 +78,7 @@ class Parameter {
       foreach ($t->getTypes() as $component) {
         $union[]= Type::resolve($component->getName(), $this->resolver());
       }
-      return new TypeHint(new TypeUnion($union));
+      return new Constraint(new TypeUnion($union));
     } else {
       $name= PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString();
 
@@ -91,13 +91,13 @@ class Parameter {
       } else if ('self' === $name) {
         $t= new XPClass($this->reflect->getDeclaringClass());
       } else {
-        return new TypeHint(Type::resolve($name, $this->resolver()));
+        return new Constraint(Type::resolve($name, $this->resolver()));
       }
       $present= true;
     }
 
     $this->meta ?? $this->meta= Reflection::meta()->ofParameter($this->method, $this->reflect);
-    return new TypeHint(
+    return new Constraint(
       isset($this->meta[DETAIL_RETURNS]) ? Type::resolve($this->meta[DETAIL_RETURNS], $this->resolver()) : $t,
       $present
     );

--- a/src/main/php/lang/reflection/Parameter.class.php
+++ b/src/main/php/lang/reflection/Parameter.class.php
@@ -37,16 +37,19 @@ class Parameter {
 
   /** @return lang.reflection.Annotations */
   public function annotations() {
-    $this->annotations ?? $this->annotations= Reflection::meta()->ofParameter($this->method, $this->reflect);
-    return new Annotations($this->annotations);
+    $this->meta ?? $this->meta= Reflection::meta()->ofParameter($this->method, $this->reflect);
+    return new Annotations($this->meta[DETAIL_ANNOTATIONS]);
   }
 
   /** @return ?lang.reflection.Annotation */
   public function annotation(string $type) {
-    $this->annotations ?? $this->annotations= Reflection::meta()->ofParameter($this->method, $this->reflect);
+    $this->meta ?? $this->meta= Reflection::meta()->ofParameter($this->method, $this->reflect);
 
     $t= strtr($type, '.', '\\');
-    return isset($this->annotations[$t]) ? new Annotation($t, $this->annotations[$t]) : null;
+    return isset($this->meta[DETAIL_ANNOTATIONS][$t])
+      ? new Annotation($t, $this->meta[DETAIL_ANNOTATIONS][$t])
+      : null
+    ;
   }
 
   /**

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -39,12 +39,10 @@ class Property extends Member {
     } else {
       $name= PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString();
 
-      // Check array, self and callable for more specific types, e.g. `string[]`,
+      // Check array and self for more specific types, e.g. `string[]`,
       // `static` or `function(): string` in api documentation
       if ('array' === $name) {
         $t= Type::$ARRAY;
-      } else if ('callable' === $name) {
-        $t= Type::$CALLABLE;
       } else if ('self' === $name) {
         $t= new XPClass($this->reflect->getDeclaringClass());
       } else {

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -22,7 +22,7 @@ class Property extends Member {
     ];
   }
 
-  /** @return lang.reflection.TypeHint */
+  /** @return lang.reflection.Constraint */
   public function constraint() {
     $t= PHP_VERSION_ID >= 70400 ? $this->reflect->getType() : null;
     if (null === $t) {
@@ -35,7 +35,7 @@ class Property extends Member {
       foreach ($t->getTypes() as $component) {
         $union[]= Type::resolve($component->getName(), $this->resolver());
       }
-      return new TypeHint(new TypeUnion($union));
+      return new Constraint(new TypeUnion($union));
     } else {
       $name= PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString();
 
@@ -46,13 +46,13 @@ class Property extends Member {
       } else if ('self' === $name) {
         $t= new XPClass($this->reflect->getDeclaringClass());
       } else {
-        return new TypeHint(Type::resolve($name, $this->resolver()));
+        return new Constraint(Type::resolve($name, $this->resolver()));
       }
       $present= true;
     }
 
     $this->meta ?? $this->meta= Reflection::meta()->ofProperty($this->reflect);
-    return new TypeHint(
+    return new Constraint(
       isset($this->meta[DETAIL_RETURNS]) ? Type::resolve($this->meta[DETAIL_RETURNS], $this->resolver()) : $t,
       $present
     );

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -4,7 +4,7 @@ use lang\Reflection;
 
 class Property extends Member {
 
-  protected function getAnnotations() { return Reflection::meta()->ofProperty($this->reflect); }
+  protected function meta() { return Reflection::meta()->ofProperty($this->reflect); }
 
   /** Returns a compound name consisting of `[CLASS]::$[NAME]`  */
   public function compoundName(): string { return strtr($this->reflect->class, '\\', '.').'::$'.$this->reflect->name; }

--- a/src/main/php/lang/reflection/Routine.class.php
+++ b/src/main/php/lang/reflection/Routine.class.php
@@ -5,7 +5,7 @@ use lang\Reflection;
 abstract class Routine extends Member {
 
   /** @return [:var] */
-  protected function getAnnotations() { return Reflection::meta()->ofMethod($this->reflect); }
+  protected function meta() { return Reflection::meta()->ofMethod($this->reflect); }
 
   /** Returns a compound name consisting of `[CLASS]::[NAME]()`  */
   public function compoundName(): string { return strtr($this->reflect->class, '\\', '.').'::'.$this->reflect->name.'()'; }

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -4,7 +4,7 @@ use lang\{Reflection, Enum, XPClass, IllegalArgumentException};
 
 class Type {
   private $reflect;
-  private $annotations= null;
+  private $meta= null;
 
   public function __construct($reflect) {
     $this->reflect= $reflect;
@@ -132,16 +132,19 @@ class Type {
 
   /** @return lang.reflection.Annotations */
   public function annotations() {
-    $this->annotations ?? $this->annotations= Reflection::meta()->ofType($this->reflect);
-    return new Annotations($this->annotations);
+    $this->meta ?? $this->meta= Reflection::meta()->ofType($this->reflect);
+    return new Annotations($this->meta[DETAIL_ANNOTATIONS]);
   }
 
   /** @return ?lang.reflection.Annotation */
   public function annotation(string $type) {
-    $this->annotations ?? $this->annotations= Reflection::meta()->ofType($this->reflect);
+    $this->meta ?? $this->meta= Reflection::meta()->ofType($this->reflect);
 
     $t= strtr($type, '.', '\\');
-    return isset($this->annotations[$t]) ? new Annotation($t, $this->annotations[$t]) : null;
+    return isset($this->meta[DETAIL_ANNOTATIONS][$t])
+      ? new Annotation($t, $this->meta[DETAIL_ANNOTATIONS][$t])
+      : null
+    ;
   }
 
   /** @return lang.reflection.Constants */

--- a/src/main/php/lang/reflection/TypeHint.class.php
+++ b/src/main/php/lang/reflection/TypeHint.class.php
@@ -3,7 +3,7 @@
 use lang\Type;
 
 class TypeHint {
-  private $type, $arguments;
+  private $type, $present;
 
   public function __construct(Type $type, bool $present= true) {
     $this->type= $type;

--- a/src/test/php/lang/reflection/unittest/MetaInformationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/MetaInformationTest.class.php
@@ -16,10 +16,12 @@ class MetaInformationTest {
       'class' => $annotations,
       2 => ['TEST' => $annotations],
       0 => ['DEFAULT' => $annotations],
-      1 => ['__construct' => [
-        DETAIL_ANNOTATIONS => ['annotated' => 'test'],
-        DETAIL_TARGET_ANNO => ['annotated' => Annotated::class, '$value' => ['annotated' => 'test']]
-      ]]
+      1 => [
+        '__construct' => [
+          DETAIL_ANNOTATIONS => ['annotated' => 'test'],
+          DETAIL_TARGET_ANNO => ['annotated' => Annotated::class, '$value' => ['annotated' => 'test']]
+        ]
+      ]
     ];
     $this->reflect= new \ReflectionClass(Fixture::class);
   }
@@ -33,31 +35,34 @@ class MetaInformationTest {
   public function type_annotations() {
     Assert::equals(
       [Annotated::class => ['test']],
-      (new MetaInformation(null))->ofType($this->reflect)
+      (new MetaInformation(null))->ofType($this->reflect)[DETAIL_ANNOTATIONS]
     );
   }
 
   #[Test]
   public function constant_annotations() {
+    $c= new \ReflectionClassConstant($this->reflect->name, 'TEST');
     Assert::equals(
       [Annotated::class => ['test']],
-      (new MetaInformation(null))->ofConstant(new \ReflectionClassConstant($this->reflect->name, 'TEST'))
+      (new MetaInformation(null))->ofConstant($c)[DETAIL_ANNOTATIONS]
     );
   }
 
   #[Test]
   public function property_annotations() {
+    $p= new \ReflectionProperty($this->reflect->name, 'DEFAULT');
     Assert::equals(
       [Annotated::class => ['test']],
-      (new MetaInformation(null))->ofProperty(new \ReflectionProperty($this->reflect->name, 'DEFAULT'))
+      (new MetaInformation(null))->ofProperty($p)[DETAIL_ANNOTATIONS]
     );
   }
 
   #[Test]
   public function method_annotations() {
+    $m= new \ReflectionMethod($this->reflect->name, '__construct');
     Assert::equals(
       [Annotated::class => ['test']],
-      (new MetaInformation(null))->ofMethod(new \ReflectionMethod($this->reflect->name, '__construct'))
+      (new MetaInformation(null))->ofMethod($m)[DETAIL_ANNOTATIONS]
     );
   }
 

--- a/src/test/php/lang/reflection/unittest/MetaInformationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/MetaInformationTest.class.php
@@ -14,8 +14,13 @@ class MetaInformationTest {
     ];
     \xp::$meta['lang.reflection.unittest.Fixture']= [
       'class' => $annotations,
-      2 => ['TEST' => $annotations],
-      0 => ['DEFAULT' => $annotations],
+      2 => [
+        'TEST' => $annotations
+      ],
+      0 => [
+        'DEFAULT' => $annotations + [DETAIL_RETURNS => 'self'],
+        'value'   => [DETAIL_ANNOTATIONS => [], DETAIL_RETURNS => 'function(): var']
+      ],
       1 => [
         '__construct' => [
           DETAIL_ANNOTATIONS => ['annotated' => 'test'],
@@ -61,6 +66,15 @@ class MetaInformationTest {
     Assert::equals(
       [Annotated::class => ['test']],
       (new MetaInformation(null))->ofProperty($p)[DETAIL_ANNOTATIONS]
+    );
+  }
+
+  #[Test]
+  public function property_type() {
+    $p= new \ReflectionProperty($this->reflect->name, 'value');
+    Assert::equals(
+      'function(): var',
+      (new MetaInformation(null))->ofProperty($p)[DETAIL_RETURNS]
     );
   }
 

--- a/src/test/php/lang/reflection/unittest/MetaInformationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/MetaInformationTest.class.php
@@ -19,7 +19,14 @@ class MetaInformationTest {
       1 => [
         '__construct' => [
           DETAIL_ANNOTATIONS => ['annotated' => 'test'],
-          DETAIL_TARGET_ANNO => ['annotated' => Annotated::class, '$value' => ['annotated' => 'test']]
+          DETAIL_TARGET_ANNO => ['annotated' => Annotated::class, '$value' => ['annotated' => 'test']],
+          DETAIL_ARGUMENTS   => ['var'],
+          DETAIL_RETURNS     => null
+        ],
+        'value' => [
+          DETAIL_ANNOTATIONS => [],
+          DETAIL_ARGUMENTS   => [],
+          DETAIL_RETURNS     => 'function(): var'
         ]
       ]
     ];
@@ -67,11 +74,29 @@ class MetaInformationTest {
   }
 
   #[Test]
+  public function method_return_type() {
+    $m= new \ReflectionMethod($this->reflect->name, 'value');
+    Assert::equals(
+      'function(): var',
+      (new MetaInformation(null))->ofMethod($m)[DETAIL_RETURNS]
+    );
+  }
+
+  #[Test]
   public function parameter_annotations() {
     $method= new \ReflectionMethod($this->reflect->name, '__construct');
     Assert::equals(
       [Annotated::class => ['test']],
-      (new MetaInformation(null))->ofParameter($method, $method->getParameters()[0])
+      (new MetaInformation(null))->ofParameter($method, $method->getParameters()[0])[DETAIL_ANNOTATIONS]
+    );
+  }
+
+  #[Test]
+  public function parameter_type() {
+    $method= new \ReflectionMethod($this->reflect->name, '__construct');
+    Assert::equals(
+      'var',
+      (new MetaInformation(null))->ofParameter($method, $method->getParameters()[0])[DETAIL_RETURNS]
     );
   }
 }

--- a/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\reflection\unittest;
 
 use lang\Primitive;
-use lang\reflection\{Modifiers, CannotAccess, AccessingFailed, TypeHint};
+use lang\reflection\{Modifiers, CannotAccess, AccessingFailed, Constraint};
 use unittest\actions\RuntimeVersion;
 use unittest\{Assert, Action, Expect, Test, AssertionFailedError};
 
@@ -132,13 +132,13 @@ class PropertiesTest {
   #[Test]
   public function type_from_apidoc() {
     $type= $this->declare('{ /** @type string */ public $fixture; }');
-    Assert::equals(new TypeHint(Primitive::$STRING, false), $type->property('fixture')->constraint());
+    Assert::equals(new Constraint(Primitive::$STRING, false), $type->property('fixture')->constraint());
   }
 
   #[Test, Action(eval: 'new RuntimeVersion(">=7.4")')]
   public function type_from_declaration() {
     $type= $this->declare('{ public string $fixture; }');
-    Assert::equals(new TypeHint(Primitive::$STRING, true), $type->property('fixture')->constraint());
+    Assert::equals(new Constraint(Primitive::$STRING, true), $type->property('fixture')->constraint());
   }
 
   #[Test]

--- a/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\reflection\unittest;
 
-use lang\reflection\{Modifiers, CannotAccess, AccessingFailed};
+use lang\Primitive;
+use lang\reflection\{Modifiers, CannotAccess, AccessingFailed, TypeHint};
 use unittest\actions\RuntimeVersion;
 use unittest\{Assert, Action, Expect, Test, AssertionFailedError};
 
@@ -126,6 +127,12 @@ class PropertiesTest {
       ['one' => $type->property('one'), 'two' => $type->property('two')],
       iterator_to_array($type->properties())
     );
+  }
+
+  #[Test]
+  public function type_from_apidoc() {
+    $type= $this->declare('{ /** @type string */ public $fixture; }');
+    Assert::equals(new TypeHint(Primitive::$STRING, false), $type->property('fixture')->constraint());
   }
 
   #[Test]

--- a/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
@@ -135,6 +135,12 @@ class PropertiesTest {
     Assert::equals(new TypeHint(Primitive::$STRING, false), $type->property('fixture')->constraint());
   }
 
+  #[Test, Action(eval: 'new RuntimeVersion(">=7.4")')]
+  public function type_from_declaration() {
+    $type= $this->declare('{ public string $fixture; }');
+    Assert::equals(new TypeHint(Primitive::$STRING, true), $type->property('fixture')->constraint());
+  }
+
   #[Test]
   public function string_representation() {
     $t= $this->declare('{ public $fixture; }');


### PR DESCRIPTION
Use `xp::$meta` if provided, only parse api docs if not.