### PR TITLE
Add reflection on packages (a.k.a. namespaces)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,6 @@ $package= Reflection::of('org.example');
 $package->name();          // org.example
 $package->literal();       // 'org\example'
 $package->types();         // iterable with Type instances
-$package->packages();      // iterable with Package instances
+$package->children();      // iterable with Package instances
 $package->classLoaders();  // iterable with lang.ClassLoader instances
 ```

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ $package= Reflection::of('org.example');
 
 $package->name();          // org.example
 $package->literal();       // 'org\example'
+$package->type('Fixture'); // Type instance
 $package->types();         // iterable with Type instances
 $package->parent()         // Package or NULL
 $package->children();      // iterable with Package instances

--- a/README.md
+++ b/README.md
@@ -138,15 +138,13 @@ foreach ($method->parameters() as $name => $parameter) {
 Packages can be reflected upon by passing namespace names to `Reflection::of()`.
 
 ```php
-namespace org\example;
-
 use lang\Reflection;
 
-$type= Reflection::of(__NAMESPACE__);
+$package= Reflection::of('org.example');
 
-$type->name();                // org.example
-$type->literal();             // 'org\example'
-$type->types();               // iterable with Type instances
-$type->packages();            // iterable with Package instances
-$type->classLoaders();        // iterable with lang.ClassLoader instances
+$package->name();          // org.example
+$package->literal();       // 'org\example'
+$package->types();         // iterable with Type instances
+$package->packages();      // iterable with Package instances
+$package->classLoaders();  // iterable with lang.ClassLoader instances
 ```

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ $package= Reflection::of('org.example');
 $package->name();          // org.example
 $package->literal();       // 'org\example'
 $package->types();         // iterable with Type instances
+$package->parent()         // Package or NULL
 $package->children();      // iterable with Package instances
 $package->classLoaders();  // iterable with lang.ClassLoader instances
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $type->modifiers();           // Modifiers<public>
 $type->comment();             // (api doc comment)
 $type->class();               // lang.XPClass instance
 $type->classLoader();         // lang.ClassLoader instance
+$type->package();             // Package or NULL
 $type->parent();              // Type or NULL
 $type->interfaces();          // Type[]
 $type->traits();              // Type[]
@@ -132,4 +133,20 @@ foreach ($method->parameters() as $name => $parameter) {
   $parameter->annotations();              // Annotations
   $parameter->annotation(Inject::class)   // Annotation or NULL
 }
+```
+
+Packages can be reflected upon by passing namespace names to `Reflection::of()`.
+
+```php
+namespace org\example;
+
+use lang\Reflection;
+
+$type= Reflection::of(__NAMESPACE__);
+
+$type->name();                // org.example
+$type->literal();             // 'org\example'
+$type->types();               // iterable with Type instances
+$type->packages();            // iterable with Package instances
+$type->classLoaders();        // iterable with lang.ClassLoader instances
 ```

--- a/src/main/php/lang/reflection/Package.class.php
+++ b/src/main/php/lang/reflection/Package.class.php
@@ -2,7 +2,11 @@
 
 use lang\{ClassLoader, IClassLoader, Reflection, IllegalArgumentException};
 
-/** Represents a namespace, which may exist in various class loaders */
+/**
+ * Represents a namespace, which may exist in various class loaders
+ *
+ * @test lang.reflection.unittest.PackageTest
+ */
 class Package {
   private $name;
 
@@ -11,14 +15,10 @@ class Package {
    * Optionally, a class loader instance can be passed - if omitted,
    * the default, composite class loader is used.
    *
-   * @param  string|string[] $arg
+   * @param  string... $components
    */
-  public function __construct($arg) {
-    if (is_array($arg)) {
-      $this->name= rtrim(strtr(implode('.', $arg), '\\', '.'), '.');
-    } else {
-      $this->name= rtrim(strtr((string)$arg, '\\', '.'), '.');
-    }
+  public function __construct(... $components) {
+    $this->name= rtrim(strtr(implode('.', $components), '\\', '.'), '.');
   }
 
   /** Returns this package's name (in dotted form) */

--- a/src/main/php/lang/reflection/Package.class.php
+++ b/src/main/php/lang/reflection/Package.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\reflection;
 
-use lang\{ClassLoader, IClassLoader, Reflection};
+use lang\{ClassLoader, IClassLoader, Reflection, IllegalArgumentException};
 
 /** Represents a namespace, which may exist in various class loaders */
 class Package {
@@ -76,6 +76,26 @@ class Package {
       if (0 === substr_compare($entry, \xp::CLASS_FILE_EXT, -$ext)) {
         yield Reflection::of($loader->loadClass0($base.substr($entry, 0, -$ext)));
       }
+    }
+  }
+
+  /**
+   * Returns a given type
+   *
+   * @param  string $name
+   * @return lang.reflection.Type
+   * @throws lang.IllegalArgumentException
+   */
+  public function type($name) {
+    $type= strtr($name, '\\', '.');
+    $p= strrpos($type, '.');
+
+    if (false === $p) {
+      return Reflection::of($this->name.'.'.$type);
+    } else if (0 === strncmp($this->name, $type, $p)) {
+      return Reflection::of($type);
+    } else {
+      throw new IllegalArgumentException('Given type '.$type.' is not in package '.$this->name);
     }
   }
 }

--- a/src/main/php/lang/reflection/Package.class.php
+++ b/src/main/php/lang/reflection/Package.class.php
@@ -43,7 +43,7 @@ class Package {
    *
    * @return iterable
    */
-  public function packages() {
+  public function children() {
     $base= $this->name.'.';
     $loader= ClassLoader::getDefault();
     foreach ($loader->packageContents($this->name) as $entry) {

--- a/src/main/php/lang/reflection/Package.class.php
+++ b/src/main/php/lang/reflection/Package.class.php
@@ -1,0 +1,71 @@
+<?php namespace lang\reflection;
+
+use lang\{ClassLoader, IClassLoader, Reflection};
+
+/** Represents a namespace, which may exist in various class loaders */
+class Package {
+  private $name;
+
+  /**
+   * Creates a new package from either a name or name components.
+   * Optionally, a class loader instance can be passed - if omitted,
+   * the default, composite class loader is used.
+   *
+   * @param  string|string[] $arg
+   */
+  public function __construct($arg) {
+    if (is_array($arg)) {
+      $this->name= rtrim(strtr(implode('.', $arg), '\\', '.'), '.');
+    } else {
+      $this->name= rtrim(strtr((string)$arg, '\\', '.'), '.');
+    }
+  }
+
+  /** Returns this package's name (in dotted form) */
+  public function name(): string { return $this->name; }
+
+  /** Returns type literal (in namespaced form) */
+  public function literal(): string { return strtr($this->name, '.', '\\'); }
+
+  /**
+   * Returns all class loaders providing this package
+   *
+   * @return iterable
+   */
+  public function classLoaders() {
+    foreach (ClassLoader::getLoaders() as $loader) {
+      if ($loader->providesPackage($this->name)) yield $loader;
+    }
+  }
+
+  /**
+   * Returns this package's child packages
+   *
+   * @return iterable
+   */
+  public function packages() {
+    $base= $this->name.'.';
+    $loader= ClassLoader::getDefault();
+    foreach ($loader->packageContents($this->name) as $entry) {
+      if ('/' === $entry[strlen($entry) - 1]) {
+        yield new self($base.substr($entry, 0, -1));
+      }
+    }
+  }
+
+  /**
+   * Returns all types in this package
+   *
+   * @return iterable
+   */
+  public function types() {
+    $ext= strlen(\xp::CLASS_FILE_EXT);
+    $base= $this->name.'.';
+    $loader= ClassLoader::getDefault();
+    foreach ($loader->packageContents($this->name) as $entry) {
+      if (0 === substr_compare($entry, \xp::CLASS_FILE_EXT, -$ext)) {
+        yield Reflection::of($loader->loadClass0($base.substr($entry, 0, -$ext)));
+      }
+    }
+  }
+}

--- a/src/main/php/lang/reflection/Package.class.php
+++ b/src/main/php/lang/reflection/Package.class.php
@@ -39,6 +39,16 @@ class Package {
   }
 
   /**
+   * Returns this package's parent, if any
+   *
+   * @return ?self
+   */
+  public function parent() {
+    $p= strrpos($this->name, '.');
+    return false === $p ? null : new Package(substr($this->name, 0, $p));
+  }
+
+  /**
    * Returns this package's child packages
    *
    * @return iterable

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -81,6 +81,16 @@ class Type {
   }
 
   /**
+   * Returns this type's package, or NULL if this type is in the global namespace.
+   *
+   * @return ?lang.reflection.Package
+   */
+  public function package() {
+    $name= $this->reflect->getNamespaceName();
+    return $name ? new Package($name) : null;
+  }
+
+  /**
    * Returns this type's parent, if any
    *
    * @return ?self

--- a/src/main/php/xp/reflection/PackageInformation.class.php
+++ b/src/main/php/xp/reflection/PackageInformation.class.php
@@ -19,7 +19,7 @@ class PackageInformation {
   public function display($out) {
     $out->format('package %s {', $this->package->name());
     $i= 0;
-    foreach ($this->package->packages() as $package) {
+    foreach ($this->package->children() as $package) {
       $out->line('  package '.$package->name());
       $i++;
     }

--- a/src/test/php/lang/reflection/unittest/PackageTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PackageTest.class.php
@@ -13,7 +13,7 @@ class PackageTest {
 
   #[Test]
   public function create_via_components() {
-    Assert::equals('lang.reflection.unittest', (new Package(['lang', 'reflection', 'unittest']))->name());
+    Assert::equals('lang.reflection.unittest', (new Package('lang', 'reflection', 'unittest'))->name());
   }
 
   #[Test]

--- a/src/test/php/lang/reflection/unittest/PackageTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PackageTest.class.php
@@ -1,0 +1,38 @@
+<?php namespace lang\reflection\unittest;
+
+use lang\reflection\Package;
+use unittest\{Assert, Test};
+
+class PackageTest {
+
+  #[Test]
+  public function name() {
+    Assert::equals('lang.reflection', (new Package('lang.reflection'))->name());
+  }
+
+  #[Test]
+  public function create_via_components() {
+    Assert::equals('lang.reflection.unittest', (new Package(['lang', 'reflection', 'unittest']))->name());
+  }
+
+  #[Test]
+  public function create_via_namespace_constant() {
+    Assert::equals('lang.reflection.unittest', (new Package(__NAMESPACE__))->name());
+  }
+
+  #[Test]
+  public function child_packages() {
+    Assert::equals(
+      [new Package('lang.reflection.unittest')],
+      iterator_to_array((new Package('lang.reflection'))->packages())
+    );
+  }
+
+  #[Test]
+  public function types() {
+    Assert::instance(
+      'lang.reflection.Type[]',
+      iterator_to_array((new Package('lang.reflection'))->types())
+    );
+  }
+}

--- a/src/test/php/lang/reflection/unittest/PackageTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PackageTest.class.php
@@ -24,7 +24,7 @@ class PackageTest {
   public function child_packages() {
     Assert::equals(
       [new Package('lang.reflection.unittest')],
-      iterator_to_array((new Package('lang.reflection'))->packages())
+      iterator_to_array((new Package('lang.reflection'))->children())
     );
   }
 

--- a/src/test/php/lang/reflection/unittest/PackageTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PackageTest.class.php
@@ -21,7 +21,12 @@ class PackageTest {
   }
 
   #[Test]
-  public function child_packages() {
+  public function parent() {
+    Assert::equals(new Package('lang'), (new Package('lang.reflection'))->parent());
+  }
+
+  #[Test]
+  public function children() {
     Assert::equals(
       [new Package('lang.reflection.unittest')],
       iterator_to_array((new Package('lang.reflection'))->children())

--- a/src/test/php/lang/reflection/unittest/PackageTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PackageTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace lang\reflection\unittest;
 
+use lang\IllegalArgumentException;
 use lang\reflection\Package;
 use unittest\{Assert, Test};
 
@@ -39,5 +40,20 @@ class PackageTest {
       'lang.reflection.Type[]',
       iterator_to_array((new Package('lang.reflection'))->types())
     );
+  }
+
+  #[Test]
+  public function type_via_short_name() {
+    Assert::equals(self::class, (new Package(__NAMESPACE__))->type('PackageTest')->literal());
+  }
+
+  #[Test]
+  public function type_via_full_name() {
+    Assert::equals(self::class, (new Package(__NAMESPACE__))->type(self::class)->literal());
+  }
+
+  #[Test, Expect(class: IllegalArgumentException::class, withMessage: 'Given type util.Date is not in package lang')]
+  public function type_with_namespace() {
+    (new Package('lang'))->type('util.Date');
   }
 }

--- a/src/test/php/lang/reflection/unittest/PackageTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PackageTest.class.php
@@ -6,9 +6,9 @@ use unittest\{Assert, Test};
 
 class PackageTest {
 
-  #[Test]
-  public function name() {
-    Assert::equals('lang.reflection', (new Package('lang.reflection'))->name());
+  #[Test, Values(['lang.reflection', 'lang\reflection', 'lang.reflection.'])]
+  public function name($arg) {
+    Assert::equals('lang.reflection', (new Package($arg))->name());
   }
 
   #[Test]

--- a/src/test/php/lang/reflection/unittest/TypeTest.class.php
+++ b/src/test/php/lang/reflection/unittest/TypeTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\reflection\unittest;
 
-use lang\reflection\{Kind, Modifiers, Annotations, Constants, Properties, Methods};
+use lang\reflection\{Kind, Modifiers, Annotations, Constants, Properties, Methods, Package};
 use lang\{ElementNotFoundException, Reflection, Enum, Runnable, XPClass, ClassLoader};
 use unittest\{Assert, Before, Test};
 
@@ -36,6 +36,16 @@ class TypeTest {
   #[Test]
   public function literal() {
     Assert::equals(self::class.'Fixture', $this->fixture->literal());
+  }
+
+  #[Test]
+  public function package() {
+    Assert::equals(new Package(__NAMESPACE__), $this->fixture->package());
+  }
+
+  #[Test]
+  public function global_namespace() {
+    Assert::null(Reflection::of(\Throwable::class)->package());
   }
 
   #[Test]


### PR DESCRIPTION
Packages can be reflected upon by passing namespace names to `Reflection::of()`.

```php
use lang\Reflection;

$package= Reflection::of('org.example');

$package->name();          // org.example
$package->literal();       // 'org\example'
$package->type('Fixture'); // Type instance
$package->types();         // iterable with Type instances
$package->parent()         // Package or NULL
$package->children();      // iterable with Package instances
$package->classLoaders();  // iterable with lang.ClassLoader instances
```
