### PR TITLE
Implement Type::initializer() for custom instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ if ($type->instantiable()) {
 }
 
 if ($unserialize= $type->initializer('__unserialize')) {
-  $instance= $type->newInstance([['name' => 'Test']]);
+  $instance= $unserialize->newInstance([['name' => 'Test']]);
 }
 
 $type->isInstance($instance); // true

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ if ($type->instantiable()) {
   $instance= $type->newInstance('Testing');
 }
 
+if ($unserialize= $type->initializer('__unserialize')) {
+  $instance= $type->newInstance([['name' => 'Test']]);
+}
+
 $type->isInstance($instance); // true
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ if ($type->instantiable()) {
   $instance= $type->newInstance('Testing');
 }
 
-if ($unserialize= $type->initializer('__unserialize')) {
-  $instance= $unserialize->newInstance([['name' => 'Test']]);
-}
-
 $type->isInstance($instance); // true
 ```
 
@@ -83,6 +79,24 @@ if ($constructor= $type->constructor()) {
   $constructor->parameters();              // Parameters
   $constructor->parameter(0);              // Parameter or NULL
   $constructor->newInstance([]);           // (instance of the type)
+}
+```
+
+Type instantiation can be controlled by using `initializer()`. It accepts either closures or named references to instance methods.
+
+```php
+// Instantiates type without invoking a constructor
+// Any passed arguments are discarded silently
+$instance= $type->initializer(null)->newInstance();
+
+// Instantiates type by providing a constructor, regardless of whether one exists or not
+// Arguments are passed on to the initializer function, which has access to $this
+$instance= $type->initializer(function($name) { $this->name= $name; })->newInstance(['Test']);
+
+// Instantiates type by selecting an instance method as an initializer
+// The unserialize callback is invoked with ['name' => 'Test']
+if ($unserialize= $type->initializer('__unserialize')) {
+  $instance= $unserialize->newInstance([['name' => 'Test']]);
 }
 ```
 

--- a/src/main/php/lang/reflection/Constructor.class.php
+++ b/src/main/php/lang/reflection/Constructor.class.php
@@ -8,7 +8,7 @@ use lang\Reflection;
  * @test lang.reflection.unittest.ConstructorTest
  * @test lang.reflection.unittest.InstantiationTest
  */
-class Constructor extends Routine {
+class Constructor extends Routine implements Instantiation {
   private $class;
 
   /** @param ReflectionClass $reflect */

--- a/src/main/php/lang/reflection/Initializer.class.php
+++ b/src/main/php/lang/reflection/Initializer.class.php
@@ -3,24 +3,24 @@
 use lang\Reflection;
 
 /**
- * Reflection for a type instantation from an initializer function
+ * Reflection for a type initializer function
  *
  * @test lang.reflection.unittest.InstantiationTest
  */
-class Instantiation extends Routine {
-  private $class, $initializer;
+class Initializer extends Routine {
+  private $class, $function;
 
   /**
    * Creates a new instantiation function
    *
    * @param  ReflectionClass $class
    * @param  ReflectionFunctionAbstract $reflect 
-   * @param  ?Closure $initializer
+   * @param  ?Closure $function
    */
-  public function __construct($class, $reflect, $initializer= null) {
+  public function __construct($class, $reflect, $function= null) {
     parent::__construct($reflect);
     $this->class= $class;
-    $this->initializer= $initializer;
+    $this->function= $function;
   }
 
   /** @return string */
@@ -47,9 +47,9 @@ class Instantiation extends Routine {
       throw new CannotInstantiate($this->class->name, $e);
     }
 
-    if (null === $this->initializer) return $instance;
+    if (null === $this->function) return $instance;
     try {
-      $this->initializer->__invoke($instance, $args, $context);
+      $this->function->__invoke($instance, $args, $context);
       return $instance;
     } catch (\Throwable $e) {
       throw new InvocationFailed($this, $e);

--- a/src/main/php/lang/reflection/Initializer.class.php
+++ b/src/main/php/lang/reflection/Initializer.class.php
@@ -7,7 +7,7 @@ use lang\Reflection;
  *
  * @test lang.reflection.unittest.InstantiationTest
  */
-class Initializer extends Routine {
+class Initializer extends Routine implements Instantiation {
   private $class, $function;
 
   /**

--- a/src/main/php/lang/reflection/Instantiation.class.php
+++ b/src/main/php/lang/reflection/Instantiation.class.php
@@ -1,0 +1,51 @@
+<?php namespace lang\reflection;
+
+use lang\Reflection;
+
+/**
+ * Reflection for a type instantation from an initializer function
+ *
+ * @test lang.reflection.unittest.InstantiationTest
+ */
+class Instantiation extends Routine {
+  private $class, $initializer;
+
+  /**
+   * Creates a new instantiation function
+   *
+   * @param  ReflectionClass $class
+   * @param  ReflectionFunctionAbstract $reflect 
+   * @param  Closure $initializer
+   */
+  public function __construct($class, $reflect, $initializer) {
+    parent::__construct($reflect);
+    $this->class= $class;
+    $this->initializer= $initializer;
+  }
+
+  /** @return string */
+  public function toString() {
+    return 'public function __construct('.$this->signature(Reflection::meta()).')';
+  }
+
+  /**
+   * Creates a new instance of the type this constructor belongs to
+   *
+   * @param  var[] $args
+   * @param  ?string|?lang.XPClass|?lang.reflection.Type $context
+   * @return object
+   * @throws lang.reflection.InvocationFailed
+   * @throws lang.reflection.CannotInstantiate
+   */
+  public function newInstance(array $args= [], $context= null) {
+    try {
+      $instance= $this->class->newInstanceWithoutConstructor();
+      $this->initializer->__invoke($instance, $args);
+      return $instance;
+    } catch (\ReflectionException $e) {
+      throw new CannotInstantiate($this->class->name, $e);
+    } catch (\Throwable $e) {
+      throw new InvocationFailed($this, $e);
+    }
+  }
+}

--- a/src/main/php/lang/reflection/Instantiation.class.php
+++ b/src/main/php/lang/reflection/Instantiation.class.php
@@ -1,0 +1,16 @@
+<?php namespace lang\reflection;
+
+/** Interface implemented by both constructors and initializers */
+interface Instantiation {
+
+  /**
+   * Creates a new instance of the type this constructor belongs to
+   *
+   * @param  var[] $args
+   * @param  ?string|?lang.XPClass|?lang.reflection.Type $context
+   * @return object
+   * @throws lang.reflection.InvocationFailed
+   * @throws lang.reflection.CannotInstantiate
+   */
+  public function newInstance(array $args= [], $context= null);
+}

--- a/src/main/php/lang/reflection/Instantiation.class.php
+++ b/src/main/php/lang/reflection/Instantiation.class.php
@@ -49,7 +49,7 @@ class Instantiation extends Routine {
 
     if (null === $this->initializer) return $instance;
     try {
-      $this->initializer->__invoke($instance, $args);
+      $this->initializer->__invoke($instance, $args, $context);
       return $instance;
     } catch (\Throwable $e) {
       throw new InvocationFailed($this, $e);

--- a/src/main/php/lang/reflection/Instantiation.class.php
+++ b/src/main/php/lang/reflection/Instantiation.class.php
@@ -15,9 +15,9 @@ class Instantiation extends Routine {
    *
    * @param  ReflectionClass $class
    * @param  ReflectionFunctionAbstract $reflect 
-   * @param  Closure $initializer
+   * @param  ?Closure $initializer
    */
-  public function __construct($class, $reflect, $initializer) {
+  public function __construct($class, $reflect, $initializer= null) {
     parent::__construct($reflect);
     $this->class= $class;
     $this->initializer= $initializer;
@@ -40,7 +40,7 @@ class Instantiation extends Routine {
   public function newInstance(array $args= [], $context= null) {
     try {
       $instance= $this->class->newInstanceWithoutConstructor();
-      $this->initializer->__invoke($instance, $args);
+      $this->initializer && $this->initializer->__invoke($instance, $args);
       return $instance;
     } catch (\ReflectionException $e) {
       throw new CannotInstantiate($this->class->name, $e);

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -145,7 +145,7 @@ class Type {
    * modifiers into account if `true` is passed as argument.
    */
   public function instantiable(bool $direct= false): bool {
-    return !$this->reflect->isSubclassOf(Enum::class) && ($direct
+    return $this->reflect->isSubclassOf(Enum::class) ? false : ($direct
       ? $this->reflect->isInstantiable()
       : !($this->reflect->isAbstract() || $this->reflect->isInterface() || $this->reflect->isTrait())
     );

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -161,6 +161,7 @@ class Type {
       });
     } else if ($this->reflect->hasMethod($initializer)) {
       $reflect= $this->reflect->getMethod($initializer);
+      $reflect->setAccessible(true);
       return new Instantiation($this->reflect, $reflect, function($instance, $args) use($reflect) {
         return $reflect->invokeArgs($instance, $args);
       });

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -140,8 +140,16 @@ class Type {
     return null; // Internal class, e.g.
   }
 
-  /** Returns whether this type is instantiable via `new` */
-  public function instantiable(): bool { return $this->reflect->isInstantiable(); }
+  /**
+   * Returns whether this type is instantiable via `new`. Only takes constructor
+   * modifiers into account if `true` is passed as argument.
+   */
+  public function instantiable(bool $direct= false): bool {
+    return !$this->reflect->isSubclassOf(Enum::class) && ($direct
+      ? $this->reflect->isInstantiable()
+      : !($this->reflect->isAbstract() || $this->reflect->isInterface() || $this->reflect->isTrait())
+    );
+  }
 
   /**
    * Returns an instantiation from a given initializer function
@@ -150,7 +158,7 @@ class Type {
    * @return ?lang.reflection.Instantiation
    */
   public function instantiation($initializer) {
-    if (!$this->reflect->isInstantiable()) return null;
+    if (!$this->instantiable()) return null;
 
     if (null === $initializer) {
       return new Instantiation($this->reflect, new \ReflectionFunction(function() { }));

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -154,22 +154,22 @@ class Type {
   /**
    * Returns an instantiation from a given initializer function
    *
-   * @param  ?string|?Closure $initializer
-   * @return ?lang.reflection.Instantiation
+   * @param  ?string|?Closure $function
+   * @return ?lang.reflection.Initializer
    */
-  public function instantiation($initializer) {
+  public function initializer($function) {
     if (!$this->instantiable()) return null;
 
-    if (null === $initializer) {
-      return new Instantiation($this->reflect, new \ReflectionFunction(function() { }));
-    } else if ($initializer instanceof \Closure) {
-      $reflect= new \ReflectionFunction($initializer);
-      return new Instantiation($this->reflect, $reflect, function($instance, $args, $context) use($initializer) {
-        return $initializer->call($instance, ...$args);
+    if (null === $function) {
+      return new Initializer($this->reflect, new \ReflectionFunction(function() { }));
+    } else if ($function instanceof \Closure) {
+      $reflect= new \ReflectionFunction($function);
+      return new Initializer($this->reflect, $reflect, function($instance, $args, $context) use($function) {
+        return $function->call($instance, ...$args);
       });
-    } else if ($this->reflect->hasMethod($initializer)) {
-      $reflect= $this->reflect->getMethod($initializer);
-      return new Instantiation($this->reflect, $reflect, function($instance, $args, $context) use($reflect) {
+    } else if ($this->reflect->hasMethod($function)) {
+      $reflect= $this->reflect->getMethod($function);
+      return new Initializer($this->reflect, $reflect, function($instance, $args, $context) use($reflect) {
         if ($context && !$reflect->isPublic() && Reflection::of($context)->isInstance($instance)) {
           $reflect->setAccessible(true);
         }

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -146,13 +146,15 @@ class Type {
   /**
    * Returns an instantiation from a given initializer function
    *
-   * @param  string|function(?): var $initializer
+   * @param  ?string|?Closure $initializer
    * @return ?lang.reflection.Instantiation
    */
   public function instantiation($initializer) {
     if (!$this->reflect->isInstantiable()) return null;
 
-    if ($initializer instanceof \Closure) {
+    if (null === $initializer) {
+      return new Instantiation($this->reflect, new \ReflectionFunction(function() { }));
+    } else if ($initializer instanceof \Closure) {
       $reflect= new \ReflectionFunction($initializer);
       return new Instantiation($this->reflect, $reflect, function($instance, $args) use($initializer) {
         return $initializer->call($instance, ...$args);

--- a/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
@@ -98,7 +98,7 @@ class InstantiationTest {
   #[Test]
   public function instantiate_constructorless() {
     $t= $this->declare('{}');
-    Assert::instance($t->class(), $t->instantiation(null)->newInstance());
+    Assert::instance($t->class(), $t->initializer(null)->newInstance());
   }
 
   #[Test]
@@ -106,7 +106,7 @@ class InstantiationTest {
     $t= $this->declare('{
       public function __construct() { throw new \lang\IllegalAccessException("Should not be called"); }
     }');
-    Assert::instance($t->class(), $t->instantiation(null)->newInstance());
+    Assert::instance($t->class(), $t->initializer(null)->newInstance());
   }
 
   #[Test]
@@ -116,8 +116,8 @@ class InstantiationTest {
       public function name() { return $this->name; }
     }');
 
-    $instantiation= $t->instantiation(function($name) { $this->name= $name; });
-    Assert::equals('Test', $instantiation->newInstance(['Test'])->name());
+    $initializer= $t->initializer(function($name) { $this->name= $name; });
+    Assert::equals('Test', $initializer->newInstance(['Test'])->name());
   }
 
   #[Test]
@@ -131,8 +131,8 @@ class InstantiationTest {
       }
     }');
 
-    $instantiation= $t->instantiation('__unserialize');
-    Assert::equals('Test', $instantiation->newInstance([['name' => 'Test']])->name());
+    $initializer= $t->initializer('__unserialize');
+    Assert::equals('Test', $initializer->newInstance([['name' => 'Test']])->name());
   }
 
   #[Test]
@@ -144,31 +144,31 @@ class InstantiationTest {
       private function __construct($name) { $this->name= $name; }
     }');
 
-    $instantiation= $t->instantiation('__construct');
-    Assert::equals('Test', $instantiation->newInstance(['Test'], $t)->name());
+    $initializer= $t->initializer('__construct');
+    Assert::equals('Test', $initializer->newInstance(['Test'], $t)->name());
   }
 
   #[Test]
   public function instantiate_on_interface() {
-    Assert::null(Reflection::of(Runnable::class)->instantiation(null));
+    Assert::null(Reflection::of(Runnable::class)->initializer(null));
   }
 
   #[Test]
   public function instantiate_with_non_existant_method_reference() {
-    Assert::null($this->declare('{}')->instantiation('__unserialize'));
+    Assert::null($this->declare('{}')->initializer('__unserialize'));
   }
 
   #[Test, Expect(InvocationFailed::class)]
   public function exceptions_from_initializer_functions_are_wrapped() {
     $t= $this->declare('{}');
-    $t->instantiation(function() { throw new IllegalAccessException('Test'); })->newInstance();
+    $t->initializer(function() { throw new IllegalAccessException('Test'); })->newInstance();
   }
 
   #[Test, Expect(InvocationFailed::class)]
-  public function exceptions_from_instantiation_methods_are_wrapped() {
+  public function exceptions_from_initializer_methods_are_wrapped() {
     $t= $this->declare('{
       public function raise() { throw new \lang\IllegalAccessException("Test"); }
     }');
-    $t->instantiation('raise')->newInstance();
+    $t->initializer('raise')->newInstance();
   }
 }

--- a/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
@@ -136,15 +136,15 @@ class InstantiationTest {
   }
 
   #[Test]
-  public function instantiate_from_private() {
+  public function instantiate_from_private_constructor() {
     $t= $this->declare('{
       private $name;
       public function name() { return $this->name; }
 
-      private function rename($name) { $this->name= $name; }
+      private function __construct($name) { $this->name= $name; }
     }');
 
-    $instantiation= $t->instantiation('rename');
+    $instantiation= $t->instantiation('__construct');
     Assert::equals('Test', $instantiation->newInstance(['Test'])->name());
   }
 

--- a/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
@@ -98,7 +98,7 @@ class InstantiationTest {
   #[Test]
   public function instantiate_constructorless() {
     $t= $this->declare('{}');
-    Assert::instance($t->class(), $t->instantiation(function() { })->newInstance());
+    Assert::instance($t->class(), $t->instantiation(null)->newInstance());
   }
 
   #[Test]
@@ -106,7 +106,7 @@ class InstantiationTest {
     $t= $this->declare('{
       public function __construct() { throw new \lang\IllegalAccessException("Should not be called"); }
     }');
-    Assert::instance($t->class(), $t->instantiation(function() { })->newInstance());
+    Assert::instance($t->class(), $t->instantiation(null)->newInstance());
   }
 
   #[Test]
@@ -137,7 +137,7 @@ class InstantiationTest {
 
   #[Test]
   public function instantiate_on_interface() {
-    Assert::null(Reflection::of('lang.Runnable')->instantiation(function() { }));
+    Assert::null(Reflection::of('lang.Runnable')->instantiation(null));
   }
 
   #[Test]

--- a/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
@@ -145,7 +145,7 @@ class InstantiationTest {
     }');
 
     $instantiation= $t->instantiation('__construct');
-    Assert::equals('Test', $instantiation->newInstance(['Test'])->name());
+    Assert::equals('Test', $instantiation->newInstance(['Test'], $t)->name());
   }
 
   #[Test]

--- a/src/test/php/lang/reflection/unittest/TypeTest.class.php
+++ b/src/test/php/lang/reflection/unittest/TypeTest.class.php
@@ -258,6 +258,18 @@ class TypeTest {
   }
 
   #[Test]
+  public function instantiable_with_private_constructor() {
+    $t= $this->declare('CTOR', [], '{ private function __construct() { } }');
+    Assert::true($t->instantiable());
+  }
+
+  #[Test]
+  public function not_instantiable_directly_with_private_constructor() {
+    $t= $this->declare('CTOR', [], '{ private function __construct() { } }');
+    Assert::true($t->instantiable(true));
+  }
+
+  #[Test]
   public function interfaces_are_not_instantiable() {
     $t= $this->declare('K_I', ['kind' => 'interface']);
     Assert::false($t->instantiable());

--- a/src/test/php/lang/reflection/unittest/TypeTest.class.php
+++ b/src/test/php/lang/reflection/unittest/TypeTest.class.php
@@ -259,14 +259,14 @@ class TypeTest {
 
   #[Test]
   public function instantiable_with_private_constructor() {
-    $t= $this->declare('CTOR', [], '{ private function __construct() { } }');
+    $t= $this->declare('P_CTOR', [], '{ private function __construct() { } }');
     Assert::true($t->instantiable());
   }
 
   #[Test]
   public function not_instantiable_directly_with_private_constructor() {
-    $t= $this->declare('CTOR', [], '{ private function __construct() { } }');
-    Assert::true($t->instantiable(true));
+    $t= $this->declare('P_CTOR', [], '{ private function __construct() { } }');
+    Assert::false($t->instantiable(true));
   }
 
   #[Test]


### PR DESCRIPTION
Implements issue #5

```php
$type= Reflection::of(...);

// Instantiates type without invoking a constructor
// Any passed arguments are discarded silently
$instance= $type->initializer(null)->newInstance();

// Instantiates type by providing a constructor, regardless of whether one exists or not
// Arguments are passed on to the initializer function, which has access to $this
$instance= $type->initializer(function($name) { $this->name= $name; })->newInstance(['Test']);

// Instantiates type by selecting an instance method as an initializer
// The unserialize callback is invoked with ['name' => 'Test']
if ($unserialize= $type->initializer('__unserialize')) {
  $instance= $unserialize->newInstance([['name' => 'Test']]);
}
```

The `initializer()` method will return *NULL* if either the type is not instantiable (e.g., because it's an interface) or if the given method does not exist.