### PR TITLE
Add Parameters::at() and Parameters::named()

### DIFF
--- a/src/main/php/lang/reflection/Members.class.php
+++ b/src/main/php/lang/reflection/Members.class.php
@@ -4,9 +4,16 @@
 abstract class Members implements \IteratorAggregate {
   protected $reflect;
 
+  /** @param ReflectionClassConstant|ReflectionProperty|ReflectionMethod $reflect */
   public function __construct($reflect) {
     $this->reflect= $reflect;
   }
 
+  /**
+   * Returns a member by a given name
+   *
+   * @param  string $name
+   * @return ?static
+   */
   public abstract function named($name);
 }

--- a/src/main/php/lang/reflection/Parameters.class.php
+++ b/src/main/php/lang/reflection/Parameters.class.php
@@ -23,6 +23,30 @@ class Parameters implements \IteratorAggregate {
     return $required ? $this->method->getNumberOfRequiredParameters() : $this->method->getNumberOfParameters();
   }
 
+  /**
+   * Gets a parameter at a given position
+   *
+   * @param  int $position
+   * @return ?lang.reflection.Parameter
+   */
+  public function at(int $position) {
+    $list= $this->method->getParameters();
+    return isset($list[$position]) ? new Parameter($list[$position], $this->method) : null;
+  }
+
+  /**
+   * Gets a parameter by a given name
+   *
+   * @param  string $name
+   * @return ?lang.reflection.Parameter
+   */
+  public function named(string $name) {
+    foreach ($this->method->getParameters() as $param) {
+      if ($name === $param->name) return new Parameter($param, $this->method);
+    }
+    return null;
+  }
+
   /** @return ?lang.reflection.Parameter */
   public function first() {
     $list= $this->method->getParameters();

--- a/src/test/php/lang/reflection/unittest/ParametersTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ParametersTest.class.php
@@ -59,9 +59,33 @@ class ParametersTest {
   }
 
   #[Test]
-  public function without_first_parameter() {
+  public function no_first_parameter() {
     $method= $this->declare('{ function fixture() { } }')->method('fixture');
     Assert::equals(null, $method->parameters()->first());
+  }
+
+  #[Test]
+  public function parameter_at() {
+    $method= $this->declare('{ function fixture($arg) { } }')->method('fixture');
+    Assert::equals($method->parameter(0), $method->parameters()->at(0));
+  }
+
+  #[Test]
+  public function no_parameter_at() {
+    $method= $this->declare('{ function fixture() { } }')->method('fixture');
+    Assert::null($method->parameters()->at(0));
+  }
+
+  #[Test]
+  public function parameter_named() {
+    $method= $this->declare('{ function fixture($arg) { } }')->method('fixture');
+    Assert::equals($method->parameter(0), $method->parameters()->named('arg'));
+  }
+
+  #[Test]
+  public function no_parameter_named() {
+    $method= $this->declare('{ function fixture() { } }')->method('fixture');
+    Assert::null($method->parameters()->named('arg'));
   }
 
   #[Test]


### PR DESCRIPTION
Both methods serve lookup purposes and complement `Routine::parameter(int|string)`, making `Parameters` consistent with `Members`.