### PR TITLE
Add Routine::accepts() to check whether given arguments would be accepted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "Reflection",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^10.0",
+    "xp-framework/core": "dev-feature/nullable-types as 10.6.0",
     "xp-framework/ast": "^7.0",
     "php" : ">=7.0.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "Reflection",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "dev-feature/nullable-types as 10.6.0",
+    "xp-framework/core": "dev-master as 10.6.0",
     "xp-framework/ast": "^7.0",
     "php" : ">=7.0.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "Reflection",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "dev-master as 10.6.0",
+    "xp-framework/core": "^10.6",
     "xp-framework/ast": "^7.0",
     "php" : ">=7.0.0"
   },

--- a/src/main/php/lang/meta/FromAttributes.class.php
+++ b/src/main/php/lang/meta/FromAttributes.class.php
@@ -47,6 +47,12 @@ class FromAttributes {
     return $this->annotations($reflect, $method->getDeclaringClass());
   }
 
+  /**
+   * Returns imports used in the class file the given class was declared in
+   *
+   * @param  \ReflectionClass $reflect
+   * @return [:string]
+   */
   public function imports($reflect) {
     static $break= [T_CLASS => true, T_INTERFACE => true, T_TRAIT => true];
 
@@ -67,11 +73,11 @@ class FromAttributes {
         $group= '';
         for ($i+= 1; $i < $s; $i++) {
           if (44 === $tokens[$i]->id) {
-            $imports[$alias ? $alias : $group]= $type.$group;
+            $imports[$alias ?? $group]= $type.$group;
             $alias= null;
             $group= '';
           } else if (125 === $tokens[$i]->id) {
-            $imports[$alias ? $alias : $group]= $type.$group;
+            $imports[$alias ?? $group]= $type.$group;
             break;
           } else if (T_AS === $tokens[$i]->id) {
             $i+= 2;

--- a/src/main/php/lang/meta/FromAttributes.class.php
+++ b/src/main/php/lang/meta/FromAttributes.class.php
@@ -47,20 +47,58 @@ class FromAttributes {
     return $this->annotations($reflect, $method->getDeclaringClass());
   }
 
-  public function evaluate($reflect, $code) {
-    static $break= [T_ATTRIBUTE => 1, T_DOC_COMMENT => 1, T_CLASS => 1, T_INTERFACE => 1, T_TRAIT => 1];
+  public function imports($reflect) {
+    static $break= [T_CLASS => true, T_INTERFACE => true, T_TRAIT => true];
 
-    // Parse namespace and imports from file
-    $ns= '';
     $tokens= \PhpToken::tokenize(file_get_contents($reflect->getFileName()));
-    foreach ($tokens as $t) {
-      if (isset($break[$t->id])) break;
-      if (T_OPEN_TAG === $t->id) continue;
-      $ns.= $t->text;
+    $imports= [];
+    for ($i= 0, $s= sizeof($tokens); $i < $s; $i++) {
+      if (isset($break[$tokens[$i]->id])) break;
+      if (T_USE !== $tokens[$i]->id) continue;
+
+      $type= '';
+      for ($i+= 2; $i < $s, !(59 === $tokens[$i]->id || 123 === $tokens[$i]->id || T_WHITESPACE === $tokens[$i]->id); $i++) {
+        $type.= $tokens[$i]->text;
+      }
+
+      // use `lang\{Type, Primitive as P}` vs. `use lang\Primitive as P;` vs. `use lang\Primitive`
+      if (123 === $tokens[$i]->id) {
+        $alias= null;
+        $group= '';
+        for ($i+= 1; $i < $s; $i++) {
+          if (44 === $tokens[$i]->id) {
+            $imports[$alias ? $alias : $group]= $type.$group;
+            $alias= null;
+            $group= '';
+          } else if (125 === $tokens[$i]->id) {
+            $imports[$alias ? $alias : $group]= $type.$group;
+            break;
+          } else if (T_AS === $tokens[$i]->id) {
+            $i+= 2;
+            $alias= $tokens[$i][1];
+          } else if (T_WHITESPACE !== $tokens[$i]->id) {
+            $group.= $tokens[$i]->text;
+          }
+        }
+      } else if (T_AS === $tokens[++$i]->id) {
+        $imports[$tokens[$i + 2]->text]= $type;
+      } else {
+        $imports[substr($type, strrpos($type, '\\') + 1)]= $type;
+      }
+    }
+    return $imports;
+  }
+
+  public function evaluate($reflect, $code) {
+    $header= '';
+    if ($namespace= $reflect->getNamespaceName()) {
+      $header.= 'namespace '.$namespace.';';
+    }
+    foreach ($this->imports($reflect) as $import => $type) {
+      $header.= 'use '.$type.' as '.$import.';';
     }
 
-    // Create, then bind closure to reflected class
-    $f= eval($ns.' return static function() { return '.$code.'; };');
+    $f= eval($header.' return static function() { return '.$code.'; };');
     return $f->bindTo(null, $reflect->name)();
   }
 }

--- a/src/main/php/lang/meta/FromSyntaxTree.class.php
+++ b/src/main/php/lang/meta/FromSyntaxTree.class.php
@@ -111,6 +111,15 @@ class FromSyntaxTree {
     return $r;
   }
 
+  public function imports($reflect) {
+    $resolver= $this->tree($reflect->name)->resolver();
+    $imports= [];
+    foreach ($resolver->imports as $alias => $type) {
+      $imports[$alias]= ltrim($type, '\\');
+    }
+    return $imports;
+  }
+
   /** @return iterable */
   public function ofType($reflect) {
     $tree= $this->tree($reflect->name);

--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -32,7 +32,7 @@ class MetaInformation {
   /**
    * Parses tags from API documentation
    *
-   * @param  ReflectionClass|ReflectionConstant|ReflectionProperty|ReflectionMethod $reflect
+   * @param  \ReflectionClass|\ReflectionConstant|\ReflectionProperty|\ReflectionMethod $reflect
    * @return [:var]
    */
   private function tags($reflect) {
@@ -45,9 +45,20 @@ class MetaInformation {
   }
 
   /**
+   * Returns a list of imports from the scope the given class was declared in
+   *
+   * @param  \ReflectionClass $reflect
+   * @return [:string]
+   */
+  public function scopeImports($reflect) {
+    $meta= &\xp::$meta[strtr($reflect->name, '\\', '.')];
+    return $meta['use'] ?? $meta['use']= $this->annotations->imports($reflect);
+  }
+
+  /**
    * Returns annotation map (type => arguments) for a given type
    *
-   * @param  ReflectionClass $reflect
+   * @param  \ReflectionClass $reflect
    * @return [:var[]]
    */
   public function typeAnnotations($reflect) {
@@ -61,7 +72,7 @@ class MetaInformation {
   /**
    * Returns API doc comment for a given type
    *
-   * @param  ReflectionClass $reflect
+   * @param  \ReflectionClass $reflect
    * @return ?string
    */
   public function typeComment($reflect) {
@@ -77,7 +88,7 @@ class MetaInformation {
   /**
    * Returns annotation map (type => arguments) for a given constant
    *
-   * @param  ReflectionClassConstant $reflect
+   * @param  \ReflectionClassConstant $reflect
    * @return [:var[]]
    */
   public function constantAnnotations($reflect) {
@@ -92,7 +103,7 @@ class MetaInformation {
   /**
    * Returns comment for a given constant
    *
-   * @param  ReflectionClassConstant $reflect
+   * @param  \ReflectionClassConstant $reflect
    * @return ?string
    */
   public function constantComment($reflect) {
@@ -109,7 +120,7 @@ class MetaInformation {
   /**
    * Returns annotation map (type => arguments) for a given property
    *
-   * @param  ReflectionProperty $reflect
+   * @param  \ReflectionProperty $reflect
    * @return [:var[]]
    */
   public function propertyAnnotations($reflect) {
@@ -124,7 +135,7 @@ class MetaInformation {
   /**
    * Returns type for a given property
    *
-   * @param  ReflectionProperty $reflect
+   * @param  \ReflectionProperty $reflect
    * @return ?string
    */
   public function propertyType($reflect) {
@@ -140,7 +151,7 @@ class MetaInformation {
   /**
    * Returns comment for a given property
    *
-   * @param  ReflectionProperty $reflect
+   * @param  \ReflectionProperty $reflect
    * @return ?string
    */
   public function propertyComment($reflect) {
@@ -157,7 +168,7 @@ class MetaInformation {
   /**
    * Returns annotation map (type => arguments) for a given method
    *
-   * @param  ReflectionMethod $reflect
+   * @param  \ReflectionMethod $reflect
    * @return [:var[]]
    */
   public function methodAnnotations($reflect) {
@@ -172,7 +183,7 @@ class MetaInformation {
   /**
    * Returns return type for a given method
    *
-   * @param  ReflectionMethod $reflect
+   * @param  \ReflectionMethod $reflect
    * @return ?string
    */
   public function methodReturns($reflect) {
@@ -187,7 +198,7 @@ class MetaInformation {
   /**
    * Returns comment for a given method
    *
-   * @param  ReflectionMethod $reflect
+   * @param  \ReflectionMethod $reflect
    * @return ?string
    */
   public function methodComment($reflect) {
@@ -204,7 +215,7 @@ class MetaInformation {
   /**
    * Returns parameter types for a given method
    *
-   * @param  ReflectionMethod $method
+   * @param  \ReflectionMethod $method
    * @return string[]
    */
   public function methodParameterTypes($method) {
@@ -221,8 +232,8 @@ class MetaInformation {
   /**
    * Returns annotation map (type => arguments) for a given method
    *
-   * @param  ReflectionMethod $method
-   * @param  ReflectionParameter $reflect
+   * @param  \ReflectionMethod $method
+   * @param  \ReflectionParameter $reflect
    * @return [:var[]]
    */
   public function parameterAnnotations($method, $reflect) {

--- a/src/main/php/lang/reflection/Member.class.php
+++ b/src/main/php/lang/reflection/Member.class.php
@@ -28,6 +28,11 @@ abstract class Member implements Value {
       'static' => function() { return new XPClass($this->reflect->class); },
       'self'   => function() { return new XPClass($this->reflect->getDeclaringClass()); },
       'parent' => function() { return new XPClass($this->reflect->getDeclaringClass()->getParentClass()); },
+      '*'      => function($type) {
+        $reflect= $this->reflect->getDeclaringClass();
+        $imports= Reflection::meta()->scopeImports($reflect);
+        return XPClass::forName($imports[$type] ?? $reflect->getNamespaceName().'\\'.$type);
+      },
     ];
   }
 
@@ -45,8 +50,7 @@ abstract class Member implements Value {
     $this->annotations ?? $this->annotations= $this->meta();
 
     $t= strtr($type, '.', '\\');
-    return isset($this->annotations[$t]) ? new Annotation($t, $this->annotations[$t]) : null
-    ;
+    return isset($this->annotations[$t]) ? new Annotation($t, $this->annotations[$t]) : null;
   }
 
   /** Returns this member's name */

--- a/src/main/php/lang/reflection/Method.class.php
+++ b/src/main/php/lang/reflection/Method.class.php
@@ -68,38 +68,16 @@ class Method extends Routine {
 
   /** @return lang.reflection.Constraint */
   public function returns() {
-    $t= $this->reflect->getReturnType();
-    if (null === $t) {
-      $present= false;
+    $present= true;
 
-      // Check for type in meta information, defaulting to `var`
-      $t= Type::$VAR;
-    } else if ($t instanceof \ReflectionUnionType) {
-      $union= [];
-      foreach ($t->getTypes() as $component) {
-        $union[]= Type::resolve($component->getName(), $this->resolver());
-      }
-      return new Constraint(new TypeUnion($union));
-    } else {
-      $name= PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString();
+    // Only use meta information if necessary
+    $api= function($set) use(&$present) {
+      $present= $set;
+      return Reflection::meta()->methodReturns($this->reflect);
+    };
 
-      // Check array, self and callable for more specific types, e.g. `string[]`,
-      // `static` or `function(): string` in meta information
-      if ('array' === $name) {
-        $t= Type::$ARRAY;
-      } else if ('callable' === $name) {
-        $t= Type::$CALLABLE;
-      } else if ('self' === $name) {
-        $t= new XPClass($this->reflect->getDeclaringClass());
-      } else {
-        return new Constraint(Type::resolve($name, $this->resolver()));
-      }
-      $present= true;
-    }
-
-    // Use meta information
-    $name= Reflection::meta()->methodReturns($this->reflect);
-    return new Constraint($name ? Type::resolve($name, $this->resolver()) : $t, $present);
+    $t= Type::forReflect($this->reflect->getReturnType(), $api, $this->resolver());
+    return new Constraint($t ?? Type::$VAR, $present);
   }
 
   /** @return string */
@@ -108,22 +86,28 @@ class Method extends Routine {
 
     // Put together return type
     $t= $this->reflect->getReturnType();
+    $nullable= '';
     if (null === $t) {
       $returns= $meta->methodReturns($this->reflect) ?? 'var';
     } else if ($t instanceof \ReflectionUnionType) {
       $name= '';
       foreach ($t->getTypes() as $component) {
-        $name.= '|'.$component->getName();
+        if ('null' === ($c= $component->getName())) {
+          $nullable= '?';
+        } else {
+          $name.= '|'.$c;
+        }
       }
       $returns= substr($name, 1);
     } else {
       $returns= strtr(PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString(), '\\', '.');
+      $t->allowsNull() && $nullable= '?';
     }
 
     return 
       Modifiers::namesOf($this->reflect->getModifiers() & ~0x1fb7f008).
       ' function '.$this->reflect->name.'('.$this->signature($meta).'): '.
-      $returns
+      $nullable.$returns
     ;
   }
 }

--- a/src/main/php/lang/reflection/Method.class.php
+++ b/src/main/php/lang/reflection/Method.class.php
@@ -76,7 +76,7 @@ class Method extends Routine {
       return Reflection::meta()->methodReturns($this->reflect);
     };
 
-    $t= Type::forReflect($this->reflect->getReturnType(), $api, $this->resolver());
+    $t= Type::resolve($this->reflect->getReturnType(), $this->resolver(), $api);
     return new Constraint($t ?? Type::$VAR, $present);
   }
 

--- a/src/main/php/lang/reflection/Parameter.class.php
+++ b/src/main/php/lang/reflection/Parameter.class.php
@@ -65,7 +65,8 @@ class Parameter {
       return $names[$this->reflect->getPosition()] ?? null;
     };
 
-    $t= Type::forReflect($this->reflect->getType(), $api, [
+    // Resolve type references against declaring class
+    $resolve= [
       'static' => function() { return new XPClass($this->method->class); },
       'self'   => function() { return new XPClass($this->method->getDeclaringClass()); },
       'parent' => function() { return new XPClass($this->method->getDeclaringClass()->getParentClass()); },
@@ -74,7 +75,8 @@ class Parameter {
         $imports= Reflection::meta()->scopeImports($reflect);
         return XPClass::forName($imports[$type] ?? $reflect->getNamespaceName().'\\'.$type);
       },
-    ]);
-    return new Constraint($t ?? Type::$VAR, $present);
+    ];
+
+    return new Constraint(Type::resolve($this->reflect->getType(), $resolve, $api) ?? Type::$VAR, $present);
   }
 }

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -31,7 +31,7 @@ class Property extends Member {
       return Reflection::meta()->propertyType($this->reflect);
     };
 
-    $t= Type::forReflect(PHP_VERSION_ID >= 70400 ? $this->reflect->getType() : null, $api, $this->resolver());
+    $t= Type::resolve(PHP_VERSION_ID >= 70400 ? $this->reflect->getType() : null, $this->resolver(), $api);
     return new Constraint($t ?? Type::$VAR, $present);
   }
 

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -21,50 +21,18 @@ class Property extends Member {
   /** Returns a compound name consisting of `[CLASS]::$[NAME]`  */
   public function compoundName(): string { return strtr($this->reflect->class, '\\', '.').'::$'.$this->reflect->name; }
 
-  /**
-   * Resolver handling `static`, `self` and `parent`.
-   *
-   * @return [:(function(string): lang.Type)]
-   */
-  protected function resolver() {
-    return [
-      'static' => function() { return new XPClass($this->reflect->class); },
-      'self'   => function() { return new XPClass($this->reflect->getDeclaringClass()); },
-      'parent' => function() { return new XPClass($this->reflect->getDeclaringClass()->getParentClass()); },
-    ];
-  }
-
   /** @return lang.reflection.Constraint */
   public function constraint() {
-    $t= PHP_VERSION_ID >= 70400 ? $this->reflect->getType() : null;
-    if (null === $t) {
-      $present= false;
+    $present= true;
 
-      // Check for type in api documentation, defaulting to `var`
-      $t= Type::$VAR;
-    } else if ($t instanceof \ReflectionUnionType) {
-      $union= [];
-      foreach ($t->getTypes() as $component) {
-        $union[]= Type::resolve($component->getName(), $this->resolver());
-      }
-      return new Constraint(new TypeUnion($union));
-    } else {
-      $name= $t->getName();
+    // Only use meta information if necessary
+    $api= function($set) use(&$present) {
+      $present= $set;
+      return Reflection::meta()->propertyType($this->reflect);
+    };
 
-      // Check array and self for more specific types, e.g. `string[]`,
-      // `static` or `function(): string` in api documentation
-      if ('array' === $name) {
-        $t= Type::$ARRAY;
-      } else if ('self' === $name) {
-        $t= new XPClass($this->reflect->getDeclaringClass());
-      } else {
-        return new Constraint(Type::resolve($name, $this->resolver()));
-      }
-      $present= true;
-    }
-
-    $name= Reflection::meta()->propertyType($this->reflect);
-    return new Constraint($name ? Type::resolve($name, $this->resolver()) : $t, $present);
+    $t= Type::forReflect(PHP_VERSION_ID >= 70400 ? $this->reflect->getType() : null, $api, $this->resolver());
+    return new Constraint($t ?? Type::$VAR, $present);
   }
 
   /**

--- a/src/main/php/lang/reflection/Routine.class.php
+++ b/src/main/php/lang/reflection/Routine.class.php
@@ -95,6 +95,7 @@ abstract class Routine extends Member {
         }
         $type= new TypeUnion($union);
       } else {
+        if (null === $arguments[$i] && $t->allowsNull()) continue;
         $name= PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString();
         if ('array' === $name || 'callable' === $name || 'self' === $name) {
           $type= Type::resolve($types[$i] ?? $name, $this->resolver());

--- a/src/main/php/lang/reflection/Routine.class.php
+++ b/src/main/php/lang/reflection/Routine.class.php
@@ -107,7 +107,7 @@ abstract class Routine extends Member {
         if ('array' === $name || 'callable' === $name || 'self' === $name) {
           $type= Type::resolve($types[$i] ?? $name, $this->resolver());
         } else {
-          $type= Type::resolve(strtr($name, '\\', '.'), $this->resolver());
+          $type= Type::resolve($name, $this->resolver());
         }
       }
 

--- a/src/main/php/lang/reflection/Routine.class.php
+++ b/src/main/php/lang/reflection/Routine.class.php
@@ -95,7 +95,12 @@ abstract class Routine extends Member {
         }
         $type= new TypeUnion($union);
       } else {
-        $type= Type::resolve(strtr(PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString(), '\\', '.'), $this->resolver());
+        $name= PHP_VERSION_ID >= 70100 ? $t->getName() : $t->__toString();
+        if ('array' === $name || 'callable' === $name || 'self' === $name) {
+          $type= Type::resolve($types[$i] ?? $name, $this->resolver());
+        } else {
+          $type= Type::resolve(strtr($name, '\\', '.'), $this->resolver());
+        }
       }
 
       // For variadic parameters, verify rest of arguments

--- a/src/main/php/lang/reflection/Routine.class.php
+++ b/src/main/php/lang/reflection/Routine.class.php
@@ -97,7 +97,7 @@ abstract class Routine extends Member {
       if (!array_key_exists($i, $arguments)) return $parameter->isOptional();
 
       // A value is present for this parameter, now check type
-      if (null === ($type= Type::forReflect($parameter->getType(), $api, $context))) continue;
+      if (null === ($type= Type::resolve($parameter->getType(), $context, $api))) continue;
 
       // For variadic parameters, verify rest of arguments
       if ($parameter->isVariadic()) {

--- a/src/main/php/lang/reflection/Routine.class.php
+++ b/src/main/php/lang/reflection/Routine.class.php
@@ -81,7 +81,7 @@ abstract class Routine extends Member {
     foreach ($this->reflect->getParameters() as $i => $parameter) {
 
       // If a given value is missing check whether parameter is optional
-      if (!isset($arguments[$i])) return $parameter->isOptional();
+      if (!array_key_exists($i, $arguments)) return $parameter->isOptional();
 
       // A value is present for this parameter, now:
       $t= $parameter->getType();

--- a/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
@@ -88,6 +88,13 @@ class AcceptsTest {
     yield [$t, [function(): int { }], false];
     yield [$t, [function(): string { }], true];
 
+    if (PHP_VERSION_ID >= 70100) {
+      $t= $this->type('<T>(?string $arg)');
+      yield [$t, [null], true];
+      yield [$t, ['test'], true];
+      yield [$t, [$this], false];
+    }
+
     if (PHP_VERSION_ID >= 80000) {
       $t= $this->type('<T>(string|int $arg)');
       yield [$t, [1], true];

--- a/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
@@ -75,12 +75,14 @@ class AcceptsTest {
     yield [$t, [$t->newInstance()], true];
 
     $t= $this->type('/** @param string[] $name */ <T>(array $name)');
-    yield [$t, [['test', 1]], false];
+    yield [$t, [[]], true];
     yield [$t, [['test', 'works']], true];
+    yield [$t, [['test', 1]], false];
 
     $t= $this->type('/** @param self[] $name */ <T>(array $name)');
-    yield [$t, [[$t->newInstance(), null]], false];
+    yield [$t, [[]], true];
     yield [$t, [[$t->newInstance()]], true];
+    yield [$t, [[$t->newInstance(), null]], false];
 
     $t= $this->type('/** @param function(): string $func */ <T>(callable $func)');
     yield [$t, [function(): int { }], false];

--- a/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
@@ -31,10 +31,15 @@ class AcceptsTest {
 
     yield ['/** @param string $name */ <T>($name)', ['test'], true];
     yield ['/** @param string $name */ <T>($name)', [1], false];
+    yield ['/** @param string[] $name */ <T>($name)', [['test', 'works']], true];
+    yield ['/** @param string[] $name */ <T>($name)', [['test', 1]], false];
 
     yield ['/** @param string|int $arg */ <T>($arg)', [1], true];
     yield ['/** @param string|int $arg */ <T>($arg)', ['test'], true];
     yield ['/** @param string|int $arg */ <T>($arg)', [$this], false];
+
+    yield ['/** @param string[] $name */ <T>(array $name)', [['test', 1]], false];
+    yield ['/** @param function(): string $func */ <T>(callable $func)', [function(string $arg): int { }], false];
 
     if (PHP_VERSION_ID >= 80000) {
       yield ['<T>(string|int $arg)', [1], true];
@@ -51,5 +56,11 @@ class AcceptsTest {
   public function accepts($fixture, $values, $expected) {
     $t= $this->declare('{ '.str_replace('<T>', 'public function fixture', $fixture).' { } }');
     Assert::equals($expected, $t->method('fixture')->accepts($values));
+  }
+
+  #[Test]
+  public function accepts_self() {
+    $t= $this->declare('{ public function fixture(self $arg) { } }');
+    Assert::true($t->method('fixture')->accepts([$t->newInstance()]));
   }
 }

--- a/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
@@ -58,9 +58,9 @@ class AcceptsTest {
     Assert::equals($expected, $t->method('fixture')->accepts($values));
   }
 
-  #[Test]
-  public function accepts_self() {
-    $t= $this->declare('{ public function fixture(self $arg) { } }');
+  #[Test, Values(['/** @param self $arg */ <T>($arg)', '<T>(self $arg)'])]
+  public function accepts_self($fixture) {
+    $t= $this->declare('{ '.str_replace('<T>', 'public function fixture', $fixture).' { } }');
     Assert::true($t->method('fixture')->accepts([$t->newInstance()]));
   }
 }

--- a/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
@@ -16,7 +16,7 @@ class AcceptsTest {
   }
 
   /** @return iterable */
-  private function values() {
+  private function fixtures() {
     $t= $this->type('<T>()');
     yield [$t, [], true];
     yield [$t, ['test'], true];
@@ -45,6 +45,11 @@ class AcceptsTest {
     yield [$t, ['test', 'works'], true];
     yield [$t, [1], false];
     yield [$t, ['test', 1], false];
+
+    $t= $this->type('<T>(\lang\reflection\unittest\AcceptsTest $arg)');
+    yield [$t, [], false];
+    yield [$t, [null], false];
+    yield [$t, [$this], true];
 
     $t= $this->type('<T>(self $arg)');
     yield [$t, [], false];
@@ -80,6 +85,16 @@ class AcceptsTest {
     yield [$t, ['test'], true];
     yield [$t, [null], true];
     yield [$t, [$this], false];
+
+    $t= $this->type('/** @param \lang\reflection\unittest\AcceptsTest $arg */ <T>($arg)');
+    yield [$t, [], false];
+    yield [$t, [null], false];
+    yield [$t, [$this], true];
+
+    $t= $this->type('/** @param lang.reflection.unittest.AcceptsTest $arg */ <T>($arg)');
+    yield [$t, [], false];
+    yield [$t, [null], false];
+    yield [$t, [$this], true];
 
     $t= $this->type('/** @param self $arg */ <T>($arg)');
     yield [$t, [], false];
@@ -139,7 +154,7 @@ class AcceptsTest {
     }
   }
 
-  #[Test, Values('values')]
+  #[Test, Values('fixtures')]
   public function accepts($t, $values, $expected) {
     Assert::equals($expected, $t->method('fixture')->accepts($values));
   }

--- a/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
@@ -1,0 +1,55 @@
+<?php namespace lang\reflection\unittest;
+
+use unittest\{Assert, Test, Values};
+
+class AcceptsTest {
+  use TypeDefinition;
+
+  /** @return iterable */
+  private function fixtures() {
+    yield ['<T>()', [], true];
+    yield ['<T>()', ['test'], true];
+
+    yield ['<T>($name)', ['test'], true];
+    yield ['<T>($name)', [], false];
+
+    yield ['<T>(string $name)', ['test'], true];
+    yield ['<T>(string $name)', [1], false];
+    yield ['<T>(string $name, int $age)', ['test'], false];
+    yield ['<T>(string $name, int $age)', ['test', 'fails'], false];
+    yield ['<T>(string $name, int $age)', ['test', 1], true];
+
+    yield ['<T>(string $name, int $age= 0)', ['test'], true];
+    yield ['<T>(string $name, int $age= 0)', ['test', 'fails'], false];
+    yield ['<T>(string $name, int $age= 0)', ['test', 1], true];
+
+    yield ['<T>(string... $args)', [], true];
+    yield ['<T>(string... $args)', ['test'], true];
+    yield ['<T>(string... $args)', ['test', 'works'], true];
+    yield ['<T>(string... $args)', [1], false];
+    yield ['<T>(string... $args)', ['test', 1], false];
+
+    yield ['/** @param string $name */ <T>($name)', ['test'], true];
+    yield ['/** @param string $name */ <T>($name)', [1], false];
+
+    yield ['/** @param string|int $arg */ <T>($arg)', [1], true];
+    yield ['/** @param string|int $arg */ <T>($arg)', ['test'], true];
+    yield ['/** @param string|int $arg */ <T>($arg)', [$this], false];
+
+    if (PHP_VERSION_ID >= 80000) {
+      yield ['<T>(string|int $arg)', [1], true];
+      yield ['<T>(string|int $arg)', ['test'], true];
+      yield ['<T>(string|int $arg)', [$this], false];
+
+      yield ['<T>(string|int... $arg)', ['test'], true];
+      yield ['<T>(string|int... $arg)', ['test', 1], true];
+      yield ['<T>(string|int... $arg)', ['test', $this], false];
+    }
+  }
+
+  #[Test, Values('fixtures')]
+  public function accepts($fixture, $values, $expected) {
+    $t= $this->declare('{ '.str_replace('<T>', 'public function fixture', $fixture).' { } }');
+    Assert::equals($expected, $t->method('fixture')->accepts($values));
+  }
+}

--- a/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
@@ -51,6 +51,12 @@ class AcceptsTest {
     yield [$t, [null], false];
     yield [$t, [$t->newInstance()], true];
 
+    $t= $this->type('<T>(self $arg= null)');
+    yield [$t, [], true];
+    yield [$t, [null], true];
+    yield [$t, ['test'], false];
+    yield [$t, [$t->newInstance()], true];
+
     $t= $this->type('<T>(self... $instances)');
     yield [$t, [], true];
     yield [$t, [null], false];
@@ -69,9 +75,21 @@ class AcceptsTest {
     yield [$t, ['test'], true];
     yield [$t, [$this], false];
 
+    $t= $this->type('/** @param ?(string|int) $arg */ <T>($arg)');
+    yield [$t, [1], true];
+    yield [$t, ['test'], true];
+    yield [$t, [null], true];
+    yield [$t, [$this], false];
+
     $t= $this->type('/** @param self $arg */ <T>($arg)');
     yield [$t, [], false];
     yield [$t, [null], false];
+    yield [$t, [$t->newInstance()], true];
+
+    $t= $this->type('/** @param ?self $arg */ <T>($arg)');
+    yield [$t, [], false];
+    yield [$t, [null], true];
+    yield [$t, ['test'], false];
     yield [$t, [$t->newInstance()], true];
 
     $t= $this->type('/** @param string[] $name */ <T>(array $name)');
@@ -90,6 +108,7 @@ class AcceptsTest {
 
     if (PHP_VERSION_ID >= 70100) {
       $t= $this->type('<T>(?string $arg)');
+      yield [$t, [], false];
       yield [$t, [null], true];
       yield [$t, ['test'], true];
       yield [$t, [$this], false];
@@ -101,8 +120,20 @@ class AcceptsTest {
       yield [$t, ['test'], true];
       yield [$t, [$this], false];
 
+      $t= $this->type('<T>(string|int|null $arg)');
+      yield [$t, [1], true];
+      yield [$t, ['test'], true];
+      yield [$t, [null], true];
+      yield [$t, [$this], false];
+
       $t= $this->type('<T>(string|int... $arg)');
       yield [$t, ['test'], true];
+      yield [$t, ['test', 1], true];
+      yield [$t, ['test', $this], false];
+
+      $t= $this->type('<T>(string|int|null... $arg)');
+      yield [$t, ['test'], true];
+      yield [$t, [null], true];
       yield [$t, ['test', 1], true];
       yield [$t, ['test', $this], false];
     }

--- a/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
@@ -51,6 +51,11 @@ class AcceptsTest {
     yield [$t, [null], false];
     yield [$t, [$t->newInstance()], true];
 
+    $t= $this->type('<T>(self... $instances)');
+    yield [$t, [], true];
+    yield [$t, [null], false];
+    yield [$t, [$t->newInstance()], true];
+
     $t= $this->type('/** @param string $name */ <T>($name)');
     yield [$t, ['test'], true];
     yield [$t, [1], false];

--- a/src/test/php/lang/reflection/unittest/MethodsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/MethodsTest.class.php
@@ -180,6 +180,15 @@ class MethodsTest {
     );
   }
 
+  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
+  public function string_representation_with_nullable_union_typed_parameter() {
+    $t= $this->declare('{ public function fixture(string|int|null $s): string { } }');
+    Assert::equals(
+      'public function fixture(?string|int $s): string',
+      $t->method('fixture')->toString()
+    );
+  }
+
   #[Test]
   public function string_representation_with_apidoc_parameter() {
     $t= $this->declare('{

--- a/src/test/php/lang/reflection/unittest/TypeDefinition.class.php
+++ b/src/test/php/lang/reflection/unittest/TypeDefinition.class.php
@@ -9,14 +9,15 @@ trait TypeDefinition {
    *
    * @param  var $declaration
    * @param  var $annotations
+   * @param  [:string] $imports
    * @return lang.reflection.Type
    */
-  private function declare($declaration, $annotations= null) {
+  private function declare($declaration, $annotations= null, $imports= []) {
     static $u= 0;
 
     return Reflection::of(ClassLoader::defineType(
       ($annotations ? $annotations.' ' : '').self::class.'Parent'.($u++),
-      ['kind' => 'class', 'extends' => null, 'implements' => [], 'use' => []],
+      ['kind' => 'class', 'extends' => null, 'implements' => [], 'use' => [], 'imports' => $imports],
       $declaration
     ));
   }


### PR DESCRIPTION
Example:

```php
class T {
  public function __construct(string $arg) { ... }
}

// Checks all required arguments are present and verifies types, also
// taking API doc @params into account
$constructor= Reflection::of(T::class)->constructor();
if ($constructor->accepts($args)) {
  $instance= $constructor->newInstance($args);
}
```