### PR TITLE
Refactor code to use Parameters::accept() instead of Routine::accepts()

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ $parameters= $method->parameters();        // Parameters instance
 $parameters->at(0);                        // Parameter or NULL
 $parameters->named('arg');                 // Parameter or NULL
 
+$args= ['test'];
+if ($parameters->accept($args)) {
+  $method->invoke(null, $args);
+}
+
 foreach ($parameters as $name => $parameter) {
   $parameter->position();                 // 0
   $parameter->name();                     // 'arg'

--- a/src/main/php/lang/reflection/Method.class.php
+++ b/src/main/php/lang/reflection/Method.class.php
@@ -76,7 +76,7 @@ class Method extends Routine {
       return Reflection::meta()->methodReturns($this->reflect);
     };
 
-    $t= Type::resolve($this->reflect->getReturnType(), $this->resolver(), $api);
+    $t= Type::resolve($this->reflect->getReturnType(), Member::resolve($this->reflect), $api);
     return new Constraint($t ?? Type::$VAR, $present);
   }
 

--- a/src/main/php/lang/reflection/Parameter.class.php
+++ b/src/main/php/lang/reflection/Parameter.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\reflection;
 
-use lang\{Reflection, Type, XPClass, IllegalStateException};
+use lang\{Reflection, Type, IllegalStateException};
 
 /**
  * Reflection for a method's or constructor's parameter
@@ -65,18 +65,9 @@ class Parameter {
       return $names[$this->reflect->getPosition()] ?? null;
     };
 
-    // Resolve type references against declaring class
-    $resolve= [
-      'static' => function() { return new XPClass($this->method->class); },
-      'self'   => function() { return new XPClass($this->method->getDeclaringClass()); },
-      'parent' => function() { return new XPClass($this->method->getDeclaringClass()->getParentClass()); },
-      '*'      => function($type) {
-        $reflect= $this->method->getDeclaringClass();
-        $imports= Reflection::meta()->scopeImports($reflect);
-        return XPClass::forName($imports[$type] ?? $reflect->getNamespaceName().'\\'.$type);
-      },
-    ];
-
-    return new Constraint(Type::resolve($this->reflect->getType(), $resolve, $api) ?? Type::$VAR, $present);
+    return new Constraint(
+      Type::resolve($this->reflect->getType(), Member::resolve($this->reflect), $api) ?? Type::$VAR,
+      $present
+    );
   }
 }

--- a/src/main/php/lang/reflection/Parameters.class.php
+++ b/src/main/php/lang/reflection/Parameters.class.php
@@ -63,15 +63,17 @@ class Parameters implements \IteratorAggregate {
   }
 
   /**
-   * Returns whether a method accepts a given argument list
+   * Returns whether these parameters accepts a given argument list. Optionally,
+   * the argument count can be passed, testing for an *exact match* with the number
+   * of parameters, e.g. to find "zero-arg getters" and "one-arg constructors".
    *
    * @param  var[] $args
-   * @param  ?int $size
+   * @param  ?int $count
    * @return bool
    */
-  public function accept(array $arguments, $size= null): bool {
+  public function accept(array $arguments, $count= null): bool {
     $parameters= $this->method->getParameters();
-    if (null !== $size && $size !== sizeof($parameters)) return false;
+    if (null !== $count && $count !== sizeof($parameters)) return false;
 
     // Only fetch api doc types if necessary
     $api= function() use(&$i, &$types) {

--- a/src/main/php/lang/reflection/Parameters.class.php
+++ b/src/main/php/lang/reflection/Parameters.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\reflection;
 
+use lang\{Reflection, Type};
+
 /**
  * Method or constructor parameters enumeration and lookup
  *
@@ -58,5 +60,45 @@ class Parameters implements \IteratorAggregate {
     foreach ($this->method->getParameters() as $parameter) {
       yield $parameter->name => new Parameter($parameter, $this->method);
     }
+  }
+
+  /**
+   * Returns whether a method accepts a given argument list
+   *
+   * @param  var[] $args
+   * @param  ?int $size
+   * @return bool
+   */
+  public function accept(array $arguments, $size= null): bool {
+    $parameters= $this->method->getParameters();
+    if (null !== $size && $size !== sizeof($parameters)) return false;
+
+    // Only fetch api doc types if necessary
+    $api= function() use(&$i, &$types) {
+      $types ?? $types= Reflection::meta()->methodParameterTypes($this->method);
+      return $types[$i] ?? null;
+    };
+
+    $context= Member::resolve($this->method);
+    foreach ($parameters as $i => $parameter) {
+
+      // If a given value is missing check whether parameter is optional
+      if (!array_key_exists($i, $arguments)) return $parameter->isOptional();
+
+      // A value is present for this parameter, now check type
+      if (null === ($type= Type::resolve($parameter->getType(), $context, $api))) continue;
+
+      // For variadic parameters, verify rest of arguments
+      if ($parameter->isVariadic()) {
+        for ($s= sizeof($arguments); $i < $s; $i++) {
+          if (!$type->isInstance($arguments[$i])) return false;
+        }
+        return true;
+      }
+
+      // ...otherwise, verify this argument and continue to next
+      if (!$type->isInstance($arguments[$i])) return false;
+    }
+    return true;
   }
 }

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -31,7 +31,7 @@ class Property extends Member {
       return Reflection::meta()->propertyType($this->reflect);
     };
 
-    $t= Type::resolve(PHP_VERSION_ID >= 70400 ? $this->reflect->getType() : null, $this->resolver(), $api);
+    $t= Type::resolve(PHP_VERSION_ID >= 70400 ? $this->reflect->getType() : null, Member::resolve($this->reflect), $api);
     return new Constraint($t ?? Type::$VAR, $present);
   }
 

--- a/src/main/php/lang/reflection/Routine.class.php
+++ b/src/main/php/lang/reflection/Routine.class.php
@@ -80,36 +80,4 @@ abstract class Routine extends Member {
   public function parameters(): Parameters {
     return new Parameters($this->reflect);
   }
-
-  /** Returns whether a method accepts a given argument list */
-  public function accepts(array $arguments): bool {
-
-    // Only fetch api doc types if necessary
-    $api= function() use(&$i, &$types) {
-      $types ?? $types= Reflection::meta()->methodParameterTypes($this->reflect);
-      return $types[$i] ?? null;
-    };
-
-    $context= $this->resolver();
-    foreach ($this->reflect->getParameters() as $i => $parameter) {
-
-      // If a given value is missing check whether parameter is optional
-      if (!array_key_exists($i, $arguments)) return $parameter->isOptional();
-
-      // A value is present for this parameter, now check type
-      if (null === ($type= Type::resolve($parameter->getType(), $context, $api))) continue;
-
-      // For variadic parameters, verify rest of arguments
-      if ($parameter->isVariadic()) {
-        for ($s= sizeof($arguments); $i < $s; $i++) {
-          if (!$type->isInstance($arguments[$i])) return false;
-        }
-        return true;
-      }
-
-      // ...otherwise, verify this argument and continue to next
-      if (!$type->isInstance($arguments[$i])) return false;
-    }
-    return true;
-  }
 }

--- a/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
@@ -187,7 +187,7 @@ class AcceptsTest {
   }
 
   #[Test, Values('fixtures')]
-  public function accepts($t, $values, $expected) {
-    Assert::equals($expected, $t->method('fixture')->accepts($values));
+  public function accept($t, $values, $expected) {
+    Assert::equals($expected, $t->method('fixture')->parameters()->accept($values));
   }
 }

--- a/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
@@ -24,170 +24,178 @@ class AcceptsTest {
   /** @return iterable */
   private function fixtures() {
     $t= $this->type('<T>()');
-    yield [$t, [], true];
-    yield [$t, ['test'], true];
+    yield [$t, [], null, true];
+    yield [$t, ['test'], null, true];
+    yield [$t, [], 0, true];
+    yield [$t, ['test'], 0, true];
+    yield [$t, [], 1, false];
+    yield [$t, ['test'], 1, false];
 
     $t= $this->type('<T>($name)');
-    yield [$t, ['test'], true];
-    yield [$t, [], false];
+    yield [$t, ['test'], null, true];
+    yield [$t, [], null, false];
+    yield [$t, [], 0, false];
+    yield [$t, ['test'], 1, true];
+    yield [$t, [], 0, false];
+    yield [$t, ['test'], 1, true];
 
     $t= $this->type('<T>(string $name)');
-    yield [$t, ['test'], true];
-    yield [$t, [1], false];
+    yield [$t, ['test'], null, true];
+    yield [$t, [1], null, false];
 
     $t= $this->type('<T>(string $name, int $age)');
-    yield [$t, ['test'], false];
-    yield [$t, ['test', 'fails'], false];
-    yield [$t, ['test', 1], true];
+    yield [$t, ['test'], null, false];
+    yield [$t, ['test', 'fails'], null, false];
+    yield [$t, ['test', 1], null, true];
 
     $t= $this->type('<T>(string $name, int $age= 0)');
-    yield [$t, ['test'], true];
-    yield [$t, ['test', 'fails'], false];
-    yield [$t, ['test', 1], true];
+    yield [$t, ['test'], null, true];
+    yield [$t, ['test', 'fails'], null, false];
+    yield [$t, ['test', 1], null, true];
 
     $t= $this->type('<T>(string... $args)');
-    yield [$t, [], true];
-    yield [$t, ['test'], true];
-    yield [$t, ['test', 'works'], true];
-    yield [$t, [1], false];
-    yield [$t, ['test', 1], false];
+    yield [$t, [], null, true];
+    yield [$t, ['test'], null, true];
+    yield [$t, ['test', 'works'], null, true];
+    yield [$t, [1], null, false];
+    yield [$t, ['test', 1], null, false];
 
     $t= $this->type('<T>(Date $arg)', ['util.Date' => null]);
-    yield [$t, [], false];
-    yield [$t, [null], false];
-    yield [$t, [new Date()], true];
+    yield [$t, [], null, false];
+    yield [$t, [null], null, false];
+    yield [$t, [new Date()], null, true];
 
     $t= $this->type('<T>(AcceptsTest $arg)');
-    yield [$t, [], false];
-    yield [$t, [null], false];
-    yield [$t, [$this], true];
+    yield [$t, [], null, false];
+    yield [$t, [null], null, false];
+    yield [$t, [$this], null, true];
 
     $t= $this->type('<T>(\lang\reflection\unittest\AcceptsTest $arg)');
-    yield [$t, [], false];
-    yield [$t, [null], false];
-    yield [$t, [$this], true];
+    yield [$t, [], null, false];
+    yield [$t, [null], null, false];
+    yield [$t, [$this], null, true];
 
     $t= $this->type('<T>(self $arg)');
-    yield [$t, [], false];
-    yield [$t, [null], false];
-    yield [$t, [$t->newInstance()], true];
+    yield [$t, [], null, false];
+    yield [$t, [null], null, false];
+    yield [$t, [$t->newInstance()], null, true];
 
     $t= $this->type('<T>(self $arg= null)');
-    yield [$t, [], true];
-    yield [$t, [null], true];
-    yield [$t, ['test'], false];
-    yield [$t, [$t->newInstance()], true];
+    yield [$t, [], null, true];
+    yield [$t, [null], null, true];
+    yield [$t, ['test'], null, false];
+    yield [$t, [$t->newInstance()], null, true];
 
     $t= $this->type('<T>(self... $instances)');
-    yield [$t, [], true];
-    yield [$t, [null], false];
-    yield [$t, [$t->newInstance()], true];
+    yield [$t, [], null, true];
+    yield [$t, [null], null, false];
+    yield [$t, [$t->newInstance()], null, true];
 
     $t= $this->type('/** @param string $name */ <T>($name)');
-    yield [$t, ['test'], true];
-    yield [$t, [1], false];
+    yield [$t, ['test'], null, true];
+    yield [$t, [1], null, false];
 
     $t= $this->type('/** @param string[] $name */ <T>($name)');
-    yield [$t, [['test', 'works']], true];
-    yield [$t, [['test', 1]], false];
+    yield [$t, [['test', 'works']], null, true];
+    yield [$t, [['test', 1]], null, false];
 
     $t= $this->type('/** @param string|int $arg */ <T>($arg)');
-    yield [$t, [1], true];
-    yield [$t, ['test'], true];
-    yield [$t, [$this], false];
+    yield [$t, [1], null, true];
+    yield [$t, ['test'], null, true];
+    yield [$t, [$this], null, false];
 
     $t= $this->type('/** @param ?(string|int) $arg */ <T>($arg)');
-    yield [$t, [1], true];
-    yield [$t, ['test'], true];
-    yield [$t, [null], true];
-    yield [$t, [$this], false];
+    yield [$t, [1], null, true];
+    yield [$t, ['test'], null, true];
+    yield [$t, [null], null, true];
+    yield [$t, [$this], null, false];
 
     $t= $this->type('/** @param Date $arg */ <T>($arg)', ['util.Date' => null]);
-    yield [$t, [], false];
-    yield [$t, [null], false];
-    yield [$t, [new Date()], true];
+    yield [$t, [], null, false];
+    yield [$t, [null], null, false];
+    yield [$t, [new Date()], null, true];
 
     $t= $this->type('/** @param AcceptsTest $arg */ <T>($arg)');
-    yield [$t, [], false];
-    yield [$t, [null], false];
-    yield [$t, [$this], true];
+    yield [$t, [], null, false];
+    yield [$t, [null], null, false];
+    yield [$t, [$this], null, true];
 
     $t= $this->type('/** @param \lang\reflection\unittest\AcceptsTest $arg */ <T>($arg)');
-    yield [$t, [], false];
-    yield [$t, [null], false];
-    yield [$t, [$this], true];
+    yield [$t, [], null, false];
+    yield [$t, [null], null, false];
+    yield [$t, [$this], null, true];
 
     $t= $this->type('/** @param lang.reflection.unittest.AcceptsTest $arg */ <T>($arg)');
-    yield [$t, [], false];
-    yield [$t, [null], false];
-    yield [$t, [$this], true];
+    yield [$t, [], null, false];
+    yield [$t, [null], null, false];
+    yield [$t, [$this], null, true];
 
     $t= $this->type('/** @param self $arg */ <T>($arg)');
-    yield [$t, [], false];
-    yield [$t, [null], false];
-    yield [$t, [$t->newInstance()], true];
+    yield [$t, [], null, false];
+    yield [$t, [null], null, false];
+    yield [$t, [$t->newInstance()], null, true];
 
     $t= $this->type('/** @param ?self $arg */ <T>($arg)');
-    yield [$t, [], false];
-    yield [$t, [null], true];
-    yield [$t, ['test'], false];
-    yield [$t, [$t->newInstance()], true];
+    yield [$t, [], null, false];
+    yield [$t, [null], null, true];
+    yield [$t, ['test'], null, false];
+    yield [$t, [$t->newInstance()], null, true];
 
     $t= $this->type('/** @param string[] $name */ <T>(array $name)');
-    yield [$t, [[]], true];
-    yield [$t, [['test', 'works']], true];
-    yield [$t, [['test', 1]], false];
+    yield [$t, [[]], null, true];
+    yield [$t, [['test', 'works']], null, true];
+    yield [$t, [['test', 1]], null, false];
 
     $t= $this->type('/** @param self[] $name */ <T>(array $name)');
-    yield [$t, [[]], true];
-    yield [$t, [[$t->newInstance()]], true];
-    yield [$t, [[$t->newInstance(), null]], false];
+    yield [$t, [[]], null, true];
+    yield [$t, [[$t->newInstance()]], null, true];
+    yield [$t, [[$t->newInstance(), null]], null, false];
 
     $t= $this->type('/** @param function(): string $func */ <T>(callable $func)');
-    yield [$t, [function(): int { }], false];
-    yield [$t, [function(): string { }], true];
+    yield [$t, [function(): int { }], null, false];
+    yield [$t, [function(): string { }], null, true];
 
     $t= $this->type("/**\n * @param string \$a\n * @param string \$b\n*/ <T>(\$a, \$b)");
-    yield [$t, [], false];
-    yield [$t, ['test'], false];
-    yield [$t, ['test', 1], false];
-    yield [$t, ['test', 'works'], true];
+    yield [$t, [], null, false];
+    yield [$t, ['test'], null, false];
+    yield [$t, ['test', 1], null, false];
+    yield [$t, ['test', 'works'], null, true];
 
     if (PHP_VERSION_ID >= 70100) {
       $t= $this->type('<T>(?string $arg)');
-      yield [$t, [], false];
-      yield [$t, [null], true];
-      yield [$t, ['test'], true];
-      yield [$t, [$this], false];
+      yield [$t, [], null, false];
+      yield [$t, [null], null, true];
+      yield [$t, ['test'], null, true];
+      yield [$t, [$this], null, false];
     }
 
     if (PHP_VERSION_ID >= 80000) {
       $t= $this->type('<T>(string|int $arg)');
-      yield [$t, [1], true];
-      yield [$t, ['test'], true];
-      yield [$t, [$this], false];
+      yield [$t, [1], null, true];
+      yield [$t, ['test'], null, true];
+      yield [$t, [$this], null, false];
 
       $t= $this->type('<T>(string|int|null $arg)');
-      yield [$t, [1], true];
-      yield [$t, ['test'], true];
-      yield [$t, [null], true];
-      yield [$t, [$this], false];
+      yield [$t, [1], null, true];
+      yield [$t, ['test'], null, true];
+      yield [$t, [null], null, true];
+      yield [$t, [$this], null, false];
 
       $t= $this->type('<T>(string|int... $arg)');
-      yield [$t, ['test'], true];
-      yield [$t, ['test', 1], true];
-      yield [$t, ['test', $this], false];
+      yield [$t, ['test'], null, true];
+      yield [$t, ['test', 1], null, true];
+      yield [$t, ['test', $this], null, false];
 
       $t= $this->type('<T>(string|int|null... $arg)');
-      yield [$t, ['test'], true];
-      yield [$t, [null], true];
-      yield [$t, ['test', 1], true];
-      yield [$t, ['test', $this], false];
+      yield [$t, ['test'], null, true];
+      yield [$t, [null], null, true];
+      yield [$t, ['test', 1], null, true];
+      yield [$t, ['test', $this], null, false];
     }
   }
 
   #[Test, Values('fixtures')]
-  public function accept($t, $values, $expected) {
-    Assert::equals($expected, $t->method('fixture')->parameters()->accept($values));
+  public function accept($t, $values, $size, $expected) {
+    Assert::equals($expected, $t->method('fixture')->parameters()->accept($values, $size));
   }
 }


### PR DESCRIPTION
On top of #8, which had this:

```php
$method= ...
if ($method->accepts($args)) {
  // ...
}
```

...now the code would look like this:

```php
$method= ...
if ($method->parameters()->accept($args)) {
  // ...
}
```

...because when testing the *parameters* accept the given arguments, it might be clearer that only the type constraints are checked and the *method* can still raise an error.