### PR TITLE
Support PHP 8.1 native enums

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "Reflection",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^10.6",
+    "xp-framework/core": "^10.8",
     "xp-framework/ast": "^7.0",
     "php" : ">=7.0.0"
   },

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -10,6 +10,11 @@ use lang\{Reflection, Enum, XPClass, IllegalArgumentException};
 class Type {
   private $reflect;
   private $annotations= null;
+  private static $ENUMS;
+
+  static function __static() {
+    self::$ENUMS= interface_exists(\UnitEnum::class, false);
+  }
 
   /** @param ReflectionClass $reflect */
   public function __construct($reflect) {
@@ -53,7 +58,7 @@ class Type {
       return Kind::$INTERFACE;
     } else if ($this->reflect->isTrait()) {
       return Kind::$TRAIT;
-    } else if ($this->reflect->isSubclassOf(Enum::class)) {
+    } else if ($this->reflect->isSubclassOf(Enum::class) || (self::$ENUMS && $this->reflect->isSubclassOf(\UnitEnum::class))) {
       return Kind::$ENUM;
     } else {
       return Kind::$CLASS;

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -10,11 +10,6 @@ use lang\{Reflection, Enum, XPClass, IllegalArgumentException};
 class Type {
   private $reflect;
   private $annotations= null;
-  private static $ENUMS;
-
-  static function __static() {
-    self::$ENUMS= interface_exists(\UnitEnum::class, false);
-  }
 
   /** @param ReflectionClass $reflect */
   public function __construct($reflect) {
@@ -58,7 +53,7 @@ class Type {
       return Kind::$INTERFACE;
     } else if ($this->reflect->isTrait()) {
       return Kind::$TRAIT;
-    } else if ($this->reflect->isSubclassOf(Enum::class) || (self::$ENUMS && $this->reflect->isSubclassOf(\UnitEnum::class))) {
+    } else if ($this->reflect->isSubclassOf(Enum::class) || $this->reflect->isSubclassOf(\UnitEnum::class)) {
       return Kind::$ENUM;
     } else {
       return Kind::$CLASS;

--- a/src/test/php/lang/reflection/unittest/TypeTest.class.php
+++ b/src/test/php/lang/reflection/unittest/TypeTest.class.php
@@ -102,7 +102,7 @@ class TypeTest {
     Assert::equals(Kind::$ENUM, $t->kind());
   }
 
-  #[Test, Action(eval: 'new VerifyThat(fn() => !self::$ENUMS && interface_exists(\UnitEnum::class, false))')]
+  #[Test, Action(eval: 'new VerifyThat(fn() => !self::$ENUMS)')]
   public function enum_kind_for_enum_lookalikes() {
     $t= $this->declare('K_LE', ['kind' => 'class', 'implements' => [\UnitEnum::class]], '{ public static $M; }');
     Assert::equals(Kind::$ENUM, $t->kind());

--- a/src/test/php/lang/reflection/unittest/TypeTest.class.php
+++ b/src/test/php/lang/reflection/unittest/TypeTest.class.php
@@ -7,6 +7,11 @@ use unittest\{Action, Assert, Before, Test};
 
 class TypeTest {
   private $fixture;
+  private static $ENUMS;
+
+  static function __static() {
+    self::$ENUMS= class_exists(\ReflectionEnum::class, false);
+  }
 
   /**
    * Declares a type and returns its reflection instance
@@ -97,13 +102,13 @@ class TypeTest {
     Assert::equals(Kind::$ENUM, $t->kind());
   }
 
-  #[Test, Action(eval: 'new VerifyThat(fn() => !class_exists(\ReflectionEnum::class, false) && interface_exists(\UnitEnum::class, false))')]
+  #[Test, Action(eval: 'new VerifyThat(fn() => !self::$ENUMS && interface_exists(\UnitEnum::class, false))')]
   public function enum_kind_for_enum_lookalikes() {
     $t= $this->declare('K_LE', ['kind' => 'class', 'implements' => [\UnitEnum::class]], '{ public static $M; }');
     Assert::equals(Kind::$ENUM, $t->kind());
   }
 
-  #[Test, Action(eval: 'new VerifyThat(fn() => class_exists(\ReflectionEnum::class, false))')]
+  #[Test, Action(eval: 'new VerifyThat(fn() => self::$ENUMS)')]
   public function enum_kind_for_native_enums() {
     $t= $this->declare('K_NE', ['kind' => 'enum'], '{ case M; }');
     Assert::equals(Kind::$ENUM, $t->kind());
@@ -188,6 +193,18 @@ class TypeTest {
   #[Test]
   public function annotation() {
     Assert::equals('annotated', $this->fixture->annotation(Annotated::class)->name());
+  }
+
+  #[Test, Action(eval: 'new VerifyThat(fn() => self::$ENUMS)')]
+  public function enum_annotation() {
+   $t= $this->declare('A_E', ['kind' => 'enum'], '{ case M; }');
+    Assert::equals('annotated', $t->annotation(Annotated::class)->name());
+  }
+
+  #[Test, Action(eval: 'new VerifyThat(fn() => self::$ENUMS)')]
+  public function enum_case_annotation() {
+   $t= $this->declare('A_C', ['kind' => 'enum'], '{ #[Annotated] case M; }');
+    Assert::equals('annotated', $t->constant('M')->annotation(Annotated::class)->name());
   }
 
   #[Test]

--- a/src/test/php/lang/reflection/unittest/TypeTest.class.php
+++ b/src/test/php/lang/reflection/unittest/TypeTest.class.php
@@ -2,7 +2,8 @@
 
 use lang\reflection\{Kind, Modifiers, Annotations, Constants, Properties, Methods, Package};
 use lang\{ElementNotFoundException, Reflection, Enum, Runnable, XPClass, ClassLoader};
-use unittest\{Assert, Before, Test};
+use unittest\actions\VerifyThat;
+use unittest\{Action, Assert, Before, Test};
 
 class TypeTest {
   private $fixture;
@@ -91,8 +92,20 @@ class TypeTest {
   }
 
   #[Test]
-  public function enum_kind() {
-    $t= $this->declare('K_E', ['kind' => 'class', 'extends' => [Enum::class]], '{ public static $M; }');
+  public function enum_kind_for_xpenums() {
+    $t= $this->declare('K_XE', ['kind' => 'class', 'extends' => [Enum::class]], '{ public static $M; }');
+    Assert::equals(Kind::$ENUM, $t->kind());
+  }
+
+  #[Test, Action(eval: 'new VerifyThat(fn() => !class_exists(\ReflectionEnum::class, false) && interface_exists(\UnitEnum::class, false))')]
+  public function enum_kind_for_enum_lookalikes() {
+    $t= $this->declare('K_LE', ['kind' => 'class', 'implements' => [\UnitEnum::class]], '{ public static $M; }');
+    Assert::equals(Kind::$ENUM, $t->kind());
+  }
+
+  #[Test, Action(eval: 'new VerifyThat(fn() => class_exists(\ReflectionEnum::class, false))')]
+  public function enum_kind_for_native_enums() {
+    $t= $this->declare('K_NE', ['kind' => 'enum'], '{ case M; }');
     Assert::equals(Kind::$ENUM, $t->kind());
   }
 


### PR DESCRIPTION
See xp-framework/core#261, consisten with `XPClass::isEnum()`, `Type::kind()` now returns `Kind::$ENUM` for:

* PHP 8.1 native enums (*when running under PHP 8.1 with php/php-src#6489*)
* PHP 8.1 enum lookalikes as created by xp-framework/compiler#106 (*when running under PHP w/o enum support*)
* XP Enums as defined in xp-framework/rfc#132 back in 2011 (*for any PHP version*)