### PR TITLE
Implement PHP 8.1 readonly properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
   "description" : "Reflection",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^10.12",
-    "xp-framework/ast": "^7.5",
+    "xp-framework/core": "^10.13",
+    "xp-framework/ast": "^7.6",
     "php" : ">=7.0.0"
   },
   "suggest" : {

--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -256,10 +256,9 @@ class MetaInformation {
    * Returns virtual properties for a given type
    *
    * @param  \ReflectionClass $reflect
-   * @param  bool $parents
    * @return [:var[]]
    */
-  public function virtualProperties($reflect, $parents= true) {
+  public function virtualProperties($reflect) {
     $r= [];
     do {
 

--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -277,7 +277,7 @@ class MetaInformation {
       $comment= $reflect->getDocComment();
       if (null === $comment) continue;
 
-      preg_match_all('/@property(\-read|\-write)? ([^ ]+) \$([^ ]+)/', $comment, $matches, PREG_SET_ORDER);
+      preg_match_all('/@property(\-read|\-write)? (.+) \$([^ ]+)/', $comment, $matches, PREG_SET_ORDER);
       $r= [];
       foreach ($matches as $match) {
         $r[$match[3]]= [Modifiers::IS_PUBLIC | ('-read' === $match[1] ? Modifiers::IS_READONLY : 0), $match[2]];

--- a/src/main/php/lang/reflection/Member.class.php
+++ b/src/main/php/lang/reflection/Member.class.php
@@ -55,7 +55,7 @@ abstract class Member implements Value {
   }
 
   /** Returns this member's name */
-  public function name(): string { return $this->reflect->name; }
+  public function name(): string { return $this->reflect->getName(); }
 
   /** Returns a compound name   */
   public abstract function compoundName(): string;

--- a/src/main/php/lang/reflection/Member.class.php
+++ b/src/main/php/lang/reflection/Member.class.php
@@ -114,7 +114,7 @@ abstract class Member implements Value {
    * @return int
    */
   public function compareTo($value) {
-    if ($value instanceof self) {
+    if ($value instanceof static) {
       $r= $this->reflect->class <=> $value->reflect->class;
       return 0 === $r ? $this->reflect->name <=> $value->reflect->name : $r;
     }

--- a/src/main/php/lang/reflection/Modifiers.class.php
+++ b/src/main/php/lang/reflection/Modifiers.class.php
@@ -14,6 +14,7 @@ class Modifiers implements Value {
   const IS_PUBLIC    = MODIFIER_PUBLIC;
   const IS_PROTECTED = MODIFIER_PROTECTED;
   const IS_PRIVATE   = MODIFIER_PRIVATE;
+  const IS_READONLY  = 0x0080; // XP 10.13: MODIFIER_READONLY
   const IS_NATIVE    = 0xF000;
 
   private static $names= [
@@ -23,7 +24,8 @@ class Modifiers implements Value {
     'static'    => self::IS_STATIC,
     'final'     => self::IS_FINAL,
     'abstract'  => self::IS_ABSTRACT,
-    'native'    => self::IS_NATIVE
+    'native'    => self::IS_NATIVE,
+    'readonly'  => self::IS_READONLY,
   ];
   private $bits;
 
@@ -111,6 +113,9 @@ class Modifiers implements Value {
 
   /** @return bool */
   public function isNative() { return 0 !== ($this->bits & self::IS_NATIVE); }
+
+  /** @return bool */
+  public function isReadonly() { return 0 !== ($this->bits & self::IS_READONLY); }
 
   /**
    * Compares a given value to this modifiers instance

--- a/src/main/php/lang/reflection/Properties.class.php
+++ b/src/main/php/lang/reflection/Properties.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\reflection;
 
 use Traversable;
+use lang\{VirtualProperty, Reflection};
 
 /**
  * Type properties enumeration and lookup
@@ -20,6 +21,9 @@ class Properties extends Members {
         yield $property->name => new Property($property);
       }
     }
+    foreach (Reflection::meta()->virtualProperties($this->reflect) as $name => $virtual) {
+      yield $name => new Property(new VirtualProperty($this->reflect, $name, $virtual));
+    }
   }
 
   /**
@@ -29,9 +33,11 @@ class Properties extends Members {
    * @return ?lang.reflection.Property
    */
   public function named($name) {
-    return $this->reflect->hasProperty($name)
-      ? new Property($this->reflect->getProperty($name))
-      : null
-    ;
+    if ($this->reflect->hasProperty($name)) {
+      return new Property($this->reflect->getProperty($name));
+    } else if ($virtual= Reflection::meta()->virtualProperties($this->reflect)[$name] ?? null) {
+      return new Property(new VirtualProperty($this->reflect, $name, $virtual));
+    }
+    return null;
   }
 }

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -20,7 +20,7 @@ class Property extends Member {
   public function comment() { return Reflection::meta()->propertyComment($this->reflect); }
 
   /** Returns a compound name consisting of `[CLASS]::$[NAME]`  */
-  public function compoundName(): string { return strtr($this->reflect->class, '\\', '.').'::$'.$this->reflect->name; }
+  public function compoundName(): string { return strtr($this->reflect->class, '\\', '.').'::$'.$this->reflect->getName(); }
 
   /** @return lang.reflection.Constraint */
   public function constraint() {
@@ -32,7 +32,11 @@ class Property extends Member {
       return Reflection::meta()->propertyType($this->reflect);
     };
 
-    $t= Type::resolve(PHP_VERSION_ID >= 70400 ? $this->reflect->getType() : null, Member::resolve($this->reflect), $api);
+    $t= Type::resolve(
+      PHP_VERSION_ID >= 70400 || '' === $this->reflect->name ? $this->reflect->getType() : null,
+      Member::resolve($this->reflect),
+      $api
+    );
     return new Constraint($t ?? Type::$VAR, $present);
   }
 
@@ -97,7 +101,7 @@ class Property extends Member {
   public function toString() {
 
     // Compile property type
-    $t= PHP_VERSION_ID >= 70400 ? $this->reflect->getType() : null;
+    $t= PHP_VERSION_ID >= 70400 || '' === $this->reflect->name ? $this->reflect->getType() : null;
     if (null === $t) {
       $name= Reflection::meta()->propertyType($this->reflect) ?? 'var';
     } else if ($t instanceof ReflectionUnionType) {
@@ -110,6 +114,6 @@ class Property extends Member {
       $name= $t->getName();
     }
 
-    return Modifiers::namesOf($this->reflect->getModifiers()).' '.$name.' $'.$this->reflect->name;
+    return Modifiers::namesOf($this->reflect->getModifiers()).' '.$name.' $'.$this->reflect->getName();
   }
 }

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\reflection;
 
 use ReflectionException, ReflectionUnionType, Throwable;
-use lang\{Reflection, XPClass, Type, TypeUnion};
+use lang\{Reflection, XPClass, Type, VirtualProperty, TypeUnion};
 
 /**
  * Reflection for a single property
@@ -20,7 +20,9 @@ class Property extends Member {
   public function comment() { return Reflection::meta()->propertyComment($this->reflect); }
 
   /** Returns a compound name consisting of `[CLASS]::$[NAME]`  */
-  public function compoundName(): string { return strtr($this->reflect->class, '\\', '.').'::$'.$this->reflect->getName(); }
+  public function compoundName(): string {
+    return strtr($this->reflect->getDeclaringClass()->name , '\\', '.').'::$'.$this->reflect->getName();
+  }
 
   /** @return lang.reflection.Constraint */
   public function constraint() {
@@ -115,5 +117,18 @@ class Property extends Member {
     }
 
     return Modifiers::namesOf($this->reflect->getModifiers()).' '.$name.' $'.$this->reflect->getName();
+  }
+
+  /**
+   * Compares this member to another value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? VirtualProperty::compare($this->reflect, $value->reflect)
+      : 1
+    ;
   }
 }

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\reflection;
 
-use lang\{Reflection, Enum, XPClass, IllegalArgumentException};
+use lang\{Reflection, Enum, XPClass, VirtualProperty, IllegalArgumentException};
 
 /**
  * Reflection for a value type: classes, interfaces, traits and enums
@@ -248,10 +248,12 @@ class Type {
 
   /** @return ?lang.reflection.Property */
   public function property(string $name) {
-    return $this->reflect->hasProperty($name)
-      ? new Property($this->reflect->getProperty($name))
-      : null
-    ;
+    if ($this->reflect->hasProperty($name)) {
+      return new Property($this->reflect->getProperty($name));
+    } else if ($virtual= Reflection::meta()->virtualProperties($this->reflect)[$name] ?? null) {
+      return new Property(new VirtualProperty($this->reflect, $name, $virtual));
+    }
+    return null;
   }
 
   /** @return lang.reflection.Properties */

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -1,13 +1,13 @@
 <?php namespace lang\reflection;
 
-use lang\{Reflection, Enum, XPClass, VirtualProperty, IllegalArgumentException};
+use lang\{Reflection, Enum, XPClass, Value, VirtualProperty, IllegalArgumentException};
 
 /**
  * Reflection for a value type: classes, interfaces, traits and enums
  *
  * @test lang.reflection.unittest.TypeTest
  */
-class Type {
+class Type implements Value {
   private $reflect;
   private $annotations= null;
 
@@ -287,6 +287,25 @@ class Type {
    */
   public function evaluate($expression) {
     return Reflection::meta()->evaluate($this->reflect, $expression);
+  }
+
+  /** @return string */
+  public function hashCode() { return md5($this->reflect->name); }
+
+  /** @return string */
+  public function toString() { return nameof($this).'<'.$this->name().'>'; }
+
+  /**
+   * Compares this member to another value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? $this->reflect->name <=> $value->reflect->name
+      : 1
+    ;
   }
 
   /** @return string */

--- a/src/main/php/module.xp
+++ b/src/main/php/module.xp
@@ -22,6 +22,8 @@ module xp-framework/reflect {
           $this->reflect= new \ReflectionClass($class);
         }
 
+        public function getName() { return $this->name; }
+
         public function getModifiers() { return MODIFIER_PUBLIC; }
 
         public function getValue() { return $this->reflect->getConstant($this->name); }

--- a/src/test/php/lang/reflection/unittest/ModifiersTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ModifiersTest.class.php
@@ -14,6 +14,7 @@ class ModifiersTest {
     yield [Modifiers::IS_PROTECTED, 'protected'];
     yield [Modifiers::IS_PRIVATE, 'private'];
     yield [Modifiers::IS_NATIVE, 'native'];
+    yield [Modifiers::IS_READONLY, 'readonly'];
     yield [Modifiers::IS_FINAL | Modifiers::IS_PUBLIC, 'public final'];
     yield [Modifiers::IS_ABSTRACT | Modifiers::IS_PUBLIC, 'public abstract'];
     yield [Modifiers::IS_ABSTRACT | Modifiers::IS_PROTECTED, 'protected abstract'];
@@ -75,6 +76,11 @@ class ModifiersTest {
   #[Test, Values([['native', true], ['public', false]])]
   public function isNative($input, $expected) {
     Assert::equals($expected, (new Modifiers($input))->isNative());
+  }
+
+  #[Test, Values([['readonly', true], ['public', false]])]
+  public function isReadonly($input, $expected) {
+    Assert::equals($expected, (new Modifiers($input))->isReadonly());
   }
 
   #[Test]

--- a/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
@@ -269,4 +269,19 @@ class PropertiesTest {
     $t= Reflection::of(WithReadonly::class);
     Assert::equals('public readonly string $fixture', $t->property('fixture')->toString());
   }
+
+  #[Test]
+  public function virtual_property_included_in_list() {
+    $t= Reflection::of(WithReadonly::class);
+    Assert::equals(
+      ['fixture' => 'public readonly'],
+      array_map(function($p) { return $p->modifiers()->names(); }, iterator_to_array($t->properties()))
+    );
+  }
+
+  #[Test]
+  public function named_virtual() {
+    $type= Reflection::of(WithReadonly::class);
+    Assert::equals($type->property('fixture'), $type->properties()->named('fixture'));
+  }
 }

--- a/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\reflection\unittest;
 
 use lang\reflection\{Modifiers, CannotAccess, AccessingFailed, Constraint};
-use lang\{Type, Primitive, TypeUnion, TypeIntersection, Reflection, XPClass};
+use lang\{Type, Primitive, TypeUnion, TypeIntersection, XPClass};
 use unittest\actions\RuntimeVersion;
 use unittest\{Assert, Action, Expect, Test, AssertionFailedError};
 
@@ -246,42 +246,5 @@ class PropertiesTest {
     } catch (CannotAccess $expected) {
       Assert::equals($t->property('fixture'), $expected->target());
     }
-  }
-
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.1")')]
-  public function native_readonly() {
-    $t= $this->declare('{ public readonly string $fixture; }');
-    Assert::equals('public readonly string $fixture', $t->property('fixture')->toString());
-  }
-
-  #[Test]
-  public function meta_readonly() {
-    $t= $this->declare('{ }');
-    \xp::$meta[$t->name()][0]['fixture']= [
-      DETAIL_RETURNS   => 'string',
-      DETAIL_ARGUMENTS => [Modifiers::IS_PUBLIC | Modifiers::IS_READONLY]
-    ];
-    Assert::equals('public readonly string $fixture', $t->property('fixture')->toString());
-  }
-
-  #[Test]
-  public function property_doccoment_readonly() {
-    $t= Reflection::of(WithReadonly::class);
-    Assert::equals('public readonly string $fixture', $t->property('fixture')->toString());
-  }
-
-  #[Test]
-  public function virtual_property_included_in_list() {
-    $t= Reflection::of(WithReadonly::class);
-    Assert::equals(
-      ['fixture' => 'public readonly'],
-      array_map(function($p) { return $p->modifiers()->names(); }, iterator_to_array($t->properties()))
-    );
-  }
-
-  #[Test]
-  public function named_virtual() {
-    $type= Reflection::of(WithReadonly::class);
-    Assert::equals($type->property('fixture'), $type->properties()->named('fixture'));
   }
 }

--- a/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\reflection\unittest;
 
 use lang\reflection\{Modifiers, CannotAccess, AccessingFailed, Constraint};
-use lang\{Type, Primitive, TypeUnion, TypeIntersection, XPClass};
+use lang\{Type, Primitive, TypeUnion, TypeIntersection, Reflection, XPClass};
 use unittest\actions\RuntimeVersion;
 use unittest\{Assert, Action, Expect, Test, AssertionFailedError};
 
@@ -246,5 +246,27 @@ class PropertiesTest {
     } catch (CannotAccess $expected) {
       Assert::equals($t->property('fixture'), $expected->target());
     }
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=8.1")')]
+  public function native_readonly() {
+    $t= $this->declare('{ public readonly string $fixture; }');
+    Assert::equals('public readonly string $fixture', $t->property('fixture')->toString());
+  }
+
+  #[Test]
+  public function meta_readonly() {
+    $t= $this->declare('{ }');
+    \xp::$meta[$t->name()][0]['fixture']= [
+      DETAIL_RETURNS   => 'string',
+      DETAIL_ARGUMENTS => [Modifiers::IS_PUBLIC | Modifiers::IS_READONLY]
+    ];
+    Assert::equals('public readonly string $fixture', $t->property('fixture')->toString());
+  }
+
+  #[Test]
+  public function property_doccoment_readonly() {
+    $t= Reflection::of(WithReadonly::class);
+    Assert::equals('public readonly string $fixture', $t->property('fixture')->toString());
   }
 }

--- a/src/test/php/lang/reflection/unittest/VirtualPropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/VirtualPropertiesTest.class.php
@@ -1,0 +1,69 @@
+<?php namespace lang\reflection\unittest;
+
+use lang\Reflection;
+use lang\reflection\{Modifiers, AccessingFailed};
+use unittest\{Assert, Values, Expect, Test};
+
+class VirtualPropertiesTest {
+  use TypeDefinition;
+
+  /** @return iterable */
+  private function fixtures() {
+    yield [Reflection::of(VirtualProperty::class)];
+
+    $t= $this->declare('{ use WithReadonly; }');
+    \xp::$meta[$t->name()][0]['fixture']= [
+      DETAIL_RETURNS   => 'string',
+      DETAIL_ARGUMENTS => [Modifiers::IS_PUBLIC | Modifiers::IS_READONLY]
+    ];
+
+    yield $t;
+    if (PHP_VERSION_ID >= 80100) {
+      yield $this->declare('{ public readonly string $fixture; }');
+    }
+  }
+
+  #[Test, Values('fixtures')]
+  public function readonly_modifier_shown_in_string_representation($type) {
+    Assert::equals('public readonly string $fixture', $type->property('fixture')->toString());
+  }
+
+  #[Test, Values('fixtures')]
+  public function virtual_property_included_in_list($type) {
+    Assert::equals(
+      ['fixture' => 'public readonly'],
+      array_map(function($p) { return $p->modifiers()->names(); }, iterator_to_array($type->properties()))
+    );
+  }
+
+  #[Test, Values('fixtures')]
+  public function named_virtual($type) {
+    Assert::equals($type->property('fixture'), $type->properties()->named('fixture'));
+  }
+
+  #[Test, Values('fixtures')]
+  public function initializing_readonly_allowed($type) {
+    $property= $type->property('fixture');
+    $instance= $type->newInstance();
+
+    $property->set($instance, 'Test');
+  }
+
+  #[Test, Values('fixtures')]
+  public function reading_readonly($type) {
+    $property= $type->property('fixture');
+    $instance= $type->newInstance();
+
+    $property->set($instance, 'Test');
+    Assert::equals('Test', $property->get($instance));
+  }
+
+  #[Test, Expect(AccessingFailed::class), Values('fixtures')]
+  public function overwriting_readonly_not_allowed($type) {
+    $property= $type->property('fixture');
+    $instance= $type->newInstance();
+
+    $property->set($instance, 'Test');
+    $property->set($instance, 'Modified');
+  }
+}

--- a/src/test/php/lang/reflection/unittest/VirtualProperty.class.php
+++ b/src/test/php/lang/reflection/unittest/VirtualProperty.class.php
@@ -1,0 +1,6 @@
+<?php namespace lang\reflection\unittest;
+
+/** @property-read string $fixture */
+class VirtualProperty {
+  use WithReadonly;
+}

--- a/src/test/php/lang/reflection/unittest/WithReadonly.class.php
+++ b/src/test/php/lang/reflection/unittest/WithReadonly.class.php
@@ -1,0 +1,34 @@
+<?php namespace lang\reflection\unittest;
+
+trait WithReadonly {
+  private $__readonly= ['fixture' => null];
+
+  public function __get($member) {
+    if (!array_key_exists($member, $this->__readonly)) {
+      trigger_error('Undefined property '.__CLASS__.'::'.$member, E_USER_WARNING);
+    }
+
+    return $this->__readonly[$member][0] ?? null;
+  }
+
+  public function __set($member, $value) {
+
+    // Illegal reassignment
+    if (isset($this->__readonly[$member])) {
+      throw new \Error('Cannot modify readonly property '.__CLASS__.'::'.$member);
+    }
+
+    // Illegal initialization outside of private scope
+    $caller= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1];
+    $scope= $caller['class'] ?? null;
+    if (__CLASS__ !== $scope && \lang\VirtualProperty::class !== $scope) {
+      throw new \Error('Cannot initialize readonly property '.__CLASS__.'::'.$member.' from '.($scope
+        ? 'scope '.$scope
+        : 'global scope'
+      ));
+    }
+
+    // Legal initialization
+    $this->__readonly[$member]= [$value];
+  }
+}


### PR DESCRIPTION
This pull request implements support PHP 8.1 readonly properties as defined in https://wiki.php.net/rfc/readonly_properties_v2

```php
class Test {
  public function __construct(public readonly int $prop = 0) { }
}

$test= new Test(6100);
$test->prop; // 6100
$test->prop= 6101; // Raises error

$prop= Reflection::of(Test::class)->property('prop');
$prop->get($test); // 6100
$prop->set($test, 6101); // Raises error
```

* [x] Readonly modifier
* [x] property() accessor
* [x] properties() enumeration
* [x] Access violations

See also https://github.com/xp-framework/core/pull/278