### PR TITLE
Add support for named arguments in PHP 7

### DIFF
--- a/src/main/php/lang/reflection/Constructor.class.php
+++ b/src/main/php/lang/reflection/Constructor.class.php
@@ -48,6 +48,15 @@ class Constructor extends Routine implements Instantiation {
         }
       }
 
+      // Support named arguments for PHP 7
+      if (PHP_VERSION_ID < 80000 && is_string(key($args))) {
+        $pass= [];
+        foreach ($this->reflect->getParameters() as $param) {
+          $pass[]= $args[$param->name] ?? ($param->isOptional() ? $param->getDefaultValue() : null);
+        }
+        return $this->class->newInstanceArgs($pass);
+      }
+
       return $this->class->newInstanceArgs($args);
     } catch (\ReflectionException $e) {
       throw new CannotInstantiate($this->class->name, $e);

--- a/src/main/php/lang/reflection/Method.class.php
+++ b/src/main/php/lang/reflection/Method.class.php
@@ -61,6 +61,16 @@ class Method extends Routine {
     }
 
     try {
+
+      // Support named arguments for PHP 7
+      if (PHP_VERSION_ID < 80000 && is_string(key($args))) {
+        $pass= [];
+        foreach ($this->reflect->getParameters() as $param) {
+          $pass[]= $args[$param->name] ?? ($param->isOptional() ? $param->getDefaultValue() : null);
+        }
+        return $this->reflect->invokeArgs($instance, $pass);
+      }
+
       return $this->reflect->invokeArgs($instance, $args);
     } catch (ReflectionException $e) {
       throw new CannotInvoke($this, $e);

--- a/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
@@ -171,4 +171,22 @@ class InstantiationTest {
     }');
     $t->initializer('raise')->newInstance();
   }
+
+  #[Test]
+  public function supports_named_arguments() {
+    $t= $this->declare('{
+      public $values;
+      public function __construct($a, $b) { $this->values= [$a, $b]; }
+    }');
+    Assert::equals([1, 2], $t->constructor()->newInstance(['b' => 2, 'a' => 1])->values);
+  }
+
+  #[Test]
+  public function supports_optional_named_arguments() {
+    $t= $this->declare('{
+      public $values;
+      public function __construct($a= 1, $b= 2) { $this->values= [$a, $b]; }
+    }');
+    Assert::equals([1, 2], $t->constructor()->newInstance(['b' => 2])->values);
+  }
 }

--- a/src/test/php/lang/reflection/unittest/InvocationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/InvocationTest.class.php
@@ -146,4 +146,20 @@ class InvocationTest {
       Assert::equals($t->method('fixture'), $expected->target());
     }
   }
+
+  #[Test]
+  public function supports_named_arguments() {
+    $t= $this->declare('{
+      public static function fixture($a, $b) { return [$a, $b]; }
+    }');
+    Assert::equals([1, 2], $t->method('fixture')->invoke(null, ['b' => 2, 'a' => 1]));
+  }
+
+  #[Test]
+  public function supports_optional_named_arguments() {
+    $t= $this->declare('{
+      public static function fixture($a= 1, $b= 2) { return [$a, $b]; }
+    }');
+    Assert::equals([1, 2], $t->method('fixture')->invoke(null, ['b' => 2]));
+  }
 }


### PR DESCRIPTION
```php
class Test {
  public static function fixture($a, $b) {
    return [$a, $b]; 
  }
}

$method= Reflection::of(Test::class)->method('fixture');

$method->invoke(null, ['a' => 1, 'b' => 2]); // [1, 2]
$method->invoke(null, ['b' => 2, 'a' => 1]); // [1, 2] - formerly returned [2, 1] in PHP 7!
```