### PR TITLE
Also accept directories on command line

### DIFF
--- a/src/main/php/xp/reflection/DirectoryInformation.class.php
+++ b/src/main/php/xp/reflection/DirectoryInformation.class.php
@@ -82,13 +82,15 @@ class DirectoryInformation {
 
     foreach ($order as $type => $types) {
       if (empty($types)) continue;
-      if ($i) $out->line();
+      $separator= $out->separator($i);
 
       ksort($types);
       $i= 0;
       foreach ($types as $type) {
-        if ($this->flags & Information::DOC && ($comment= $type->comment())) {
-          $out->line();
+        if ($this->flags & Information::DOC) {
+          $out->separator(!$separator) || $separator= false;
+
+          $comment= $type->comment() ?? '(Undocumented)';
           $p= strpos($comment, "\n\n");
           $s= min(strpos($comment, '. ') ?: $p, strpos($comment, ".\n") ?: $p);
 

--- a/src/main/php/xp/reflection/DirectoryInformation.class.php
+++ b/src/main/php/xp/reflection/DirectoryInformation.class.php
@@ -52,13 +52,11 @@ class DirectoryInformation {
   private function types() {
     $base= null === $this->base ? '' : $this->base.'.';
     $ext= strlen(\xp::CLASS_FILE_EXT);
-    $loader= ClassLoader::getDefault();
     foreach ($this->loader->packageContents($this->base) as $entry) {
       if (0 === substr_compare($entry, \xp::CLASS_FILE_EXT, -$ext)) {
         yield Reflection::of($this->loader->loadClass0($base.substr($entry, 0, -$ext)));
       }
     }
-
   }
 
   public function display($out) {

--- a/src/main/php/xp/reflection/DirectoryInformation.class.php
+++ b/src/main/php/xp/reflection/DirectoryInformation.class.php
@@ -1,6 +1,6 @@
 <?php namespace xp\reflection;
 
-use lang\{ClassLoader, Reflection, IllegalArgumentException};
+use lang\{ClassLoader, FileSystemClassLoader, Reflection, IllegalArgumentException};
 
 class DirectoryInformation {
   private $loader, $base, $flags;
@@ -17,6 +17,8 @@ class DirectoryInformation {
 
     // Locate directory in class path
     foreach (ClassLoader::getLoaders() as $loader) {
+      if (!($loader instanceof FileSystemClassLoader)) continue;
+
       $l= strlen($loader->path);
       if (0 === strncasecmp($target, $loader->path, $l)) {
         $this->loader= $loader;

--- a/src/main/php/xp/reflection/DirectoryInformation.class.php
+++ b/src/main/php/xp/reflection/DirectoryInformation.class.php
@@ -40,17 +40,6 @@ class DirectoryInformation {
     yield $this->loader;
   }
 
-  /** @return iterable */
-  private function types() {
-    $base= null === $this->base ? '' : $this->base.'.';
-    $ext= strlen(\xp::CLASS_FILE_EXT);
-    foreach ($this->loader->packageContents($this->base) as $entry) {
-      if (0 === substr_compare($entry, \xp::CLASS_FILE_EXT, -$ext)) {
-        yield Reflection::of($this->loader->loadClass0($base.substr($entry, 0, -$ext)));
-      }
-    }
-  }
-
   public function display($out) {
     if (null === $this->base) {
       $out->format('package {');
@@ -70,9 +59,14 @@ class DirectoryInformation {
 
     // Compile types into a custom order
     $order= ['interface' => [], 'trait' => [], 'enum' => [], 'class' => []];
-    foreach ($this->types() as $type) {
-      $order[$type->kind()->name()][$type->name()]= $type;
+    $ext= strlen(\xp::CLASS_FILE_EXT);
+    foreach ($this->loader->packageContents($this->base) as $entry) {
+      if (0 === substr_compare($entry, \xp::CLASS_FILE_EXT, -$ext)) {
+        $type= Reflection::of($this->loader->loadClass0($base.substr($entry, 0, -$ext)));
+        $order[$type->kind()->name()][$type->name()]= $type;
+      }
     }
+
     foreach ($order as $type => $types) {
       if (empty($types)) continue;
       if ($i) $out->line();

--- a/src/main/php/xp/reflection/DirectoryInformation.class.php
+++ b/src/main/php/xp/reflection/DirectoryInformation.class.php
@@ -1,0 +1,104 @@
+<?php namespace xp\reflection;
+
+use lang\{ClassLoader, Reflection, IllegalArgumentException};
+
+class DirectoryInformation {
+  private $loader, $base, $flags;
+
+  /**
+   * Creates a new directory information instance
+   *
+   * @param  string $dir
+   * @param  int $flags
+   */
+  public function __construct($dir, $flags) {
+    $target= rtrim(realpath($dir), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+    $this->flags= $flags;
+
+    // Locate directory in class path
+    foreach (ClassLoader::getLoaders() as $loader) {
+      $l= strlen($loader->path);
+      if (0 === strncasecmp($target, $loader->path, $l)) {
+        $this->loader= $loader;
+
+        if ($l === strlen($target)) {
+          $this->base= null;
+        } else {
+          $this->base= strtr(substr($target, $l, -1), [DIRECTORY_SEPARATOR => '.']);
+        }
+        return;
+      }
+    }
+
+    throw new IllegalArgumentException('Directory '.$dir.' is not in class path');
+  }
+
+  /** @return iterable */
+  public function sources() {
+    yield $this->loader;
+  }
+
+  /** @return iterable */
+  private function children() {
+    $base= null === $this->base ? '' : $this->base.'.';
+    foreach ($this->loader->packageContents($this->base) as $entry) {
+      if ('/' === $entry[strlen($entry) - 1]) {
+        yield $base.substr($entry, 0, -1);
+      }
+    }
+  }
+
+  /** @return iterable */
+  private function types() {
+    $base= null === $this->base ? '' : $this->base.'.';
+    $ext= strlen(\xp::CLASS_FILE_EXT);
+    $loader= ClassLoader::getDefault();
+    foreach ($this->loader->packageContents($this->base) as $entry) {
+      if (0 === substr_compare($entry, \xp::CLASS_FILE_EXT, -$ext)) {
+        yield Reflection::of($this->loader->loadClass0($base.substr($entry, 0, -$ext)));
+      }
+    }
+
+  }
+
+  public function display($out) {
+    $this->base ? $out->format('package %s {', $this->base) : $out->format('package {');
+    $i= 0;
+    foreach ($this->children() as $package) {
+      $out->line('  package '.$package);
+      $i++;
+    }
+
+    // Compile types into a custom order
+    $order= ['interface' => [], 'trait' => [], 'enum' => [], 'class' => []];
+    foreach ($this->types() as $type) {
+      $order[$type->kind()->name()][$type->name()]= $type;
+    }
+    foreach ($order as $type => $types) {
+      if (empty($types)) continue;
+      if ($i) $out->line();
+
+      ksort($types);
+      $i= 0;
+      foreach ($types as $type) {
+        if ($this->flags & Information::DOC && ($comment= $type->comment())) {
+          $out->line();
+          $p= strpos($comment, "\n\n");
+          $s= min(strpos($comment, '. ') ?: $p, strpos($comment, ".\n") ?: $p);
+
+          if (false === $s || $s > $p) {
+            $purpose= false === $p ? trim($comment) : substr($comment, 0, $p);
+          } else {
+            $purpose= substr($comment, 0, $s);
+          }
+          $out->documentation(str_replace(["\n", '  '], [' ', ' '], trim($purpose)), '  ');
+        }
+
+        $out->line('  ', $type->modifiers()->names(true).' '.$type->kind()->name().' '.$type->name());
+        $i++;
+      }
+    }
+
+    $out->line('}');
+  }
+}

--- a/src/main/php/xp/reflection/DirectoryInformation.class.php
+++ b/src/main/php/xp/reflection/DirectoryInformation.class.php
@@ -41,16 +41,6 @@ class DirectoryInformation {
   }
 
   /** @return iterable */
-  private function children() {
-    $base= null === $this->base ? '' : $this->base.'.';
-    foreach ($this->loader->packageContents($this->base) as $entry) {
-      if ('/' === $entry[strlen($entry) - 1]) {
-        yield $base.substr($entry, 0, -1);
-      }
-    }
-  }
-
-  /** @return iterable */
   private function types() {
     $base= null === $this->base ? '' : $this->base.'.';
     $ext= strlen(\xp::CLASS_FILE_EXT);
@@ -62,11 +52,20 @@ class DirectoryInformation {
   }
 
   public function display($out) {
-    $this->base ? $out->format('package %s {', $this->base) : $out->format('package {');
+    if (null === $this->base) {
+      $out->format('package {');
+      $base= '';
+    } else {
+      $out->format('package %s {', $this->base);
+      $base= $this->base.'.';
+    }
+
     $i= 0;
-    foreach ($this->children() as $package) {
-      $out->line('  package '.$package);
-      $i++;
+    foreach ($this->loader->packageContents($this->base) as $entry) {
+      if ('/' === $entry[strlen($entry) - 1]) {
+        $out->line('  package '.$base.substr($entry, 0, -1));
+        $i++;
+      }
     }
 
     // Compile types into a custom order

--- a/src/main/php/xp/reflection/DirectoryInformation.class.php
+++ b/src/main/php/xp/reflection/DirectoryInformation.class.php
@@ -13,6 +13,7 @@ class DirectoryInformation {
    *
    * @param  string $dir
    * @param  int $flags
+   * @throws lang.IllegalArgumentException if directory is not in class path
    */
   public function __construct($dir, $flags) {
     $target= rtrim(realpath($dir), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
@@ -39,7 +40,8 @@ class DirectoryInformation {
   }
 
   /**
-   * Returns types in a given base package
+   * Returns types in a given base package. Asks the primary class loader,
+   * then all the others.
    * 
    * @param  string $base
    * @return iterable

--- a/src/main/php/xp/reflection/DirectoryInformation.class.php
+++ b/src/main/php/xp/reflection/DirectoryInformation.class.php
@@ -2,10 +2,10 @@
 
 use lang\{ClassLoader, FileSystemClassLoader, Reflection, IllegalArgumentException};
 
-class DirectoryInformation {
+class DirectoryInformation extends TypeListing {
   const PRIMARY = 0;
 
-  private $base, $flags;
+  private $base;
   private $loaders= [self::PRIMARY => null];
 
   /**
@@ -74,39 +74,7 @@ class DirectoryInformation {
       }
     }
 
-    // Compile types into a custom order
-    $order= ['interface' => [], 'trait' => [], 'enum' => [], 'class' => []];
-    foreach ($this->typesIn($base) as $type) {
-      $order[$type->kind()->name()][$type->name()]= $type;
-    }
-
-    foreach ($order as $type => $types) {
-      if (empty($types)) continue;
-      $separator= $out->separator($i);
-
-      ksort($types);
-      $i= 0;
-      foreach ($types as $type) {
-        if ($this->flags & Information::DOC) {
-          $out->separator(!$separator) || $separator= false;
-
-          $comment= $type->comment() ?? '(Undocumented)';
-          $p= strpos($comment, "\n\n");
-          $s= min(strpos($comment, '. ') ?: $p, strpos($comment, ".\n") ?: $p);
-
-          if (false === $s || $s > $p) {
-            $purpose= false === $p ? trim($comment) : substr($comment, 0, $p);
-          } else {
-            $purpose= substr($comment, 0, $s);
-          }
-          $out->documentation(str_replace(["\n", '  '], [' ', ' '], trim($purpose)), '  ');
-        }
-
-        $out->line('  ', $type->modifiers()->names(true).' '.$type->kind()->name().' '.$type->name());
-        $i++;
-      }
-    }
-
+    $this->list($out, $i, $this->typesIn($base));
     $out->line('}');
   }
 }

--- a/src/main/php/xp/reflection/Information.class.php
+++ b/src/main/php/xp/reflection/Information.class.php
@@ -51,4 +51,15 @@ abstract class Information extends Enum {
   public static function forPackage($name, $flags) {
     return new PackageInformation($name, $flags);
   }
+
+  /**
+   * Factory for information based on a directory
+   *
+   * @param  string $name
+   * @param  int $flags
+   * @return xp.reflection.DirectoryInformation
+   */
+  public static function forDirectory($name, $flags) {
+    return new DirectoryInformation($name, $flags);
+  }
 }

--- a/src/main/php/xp/reflection/PackageInformation.class.php
+++ b/src/main/php/xp/reflection/PackageInformation.class.php
@@ -2,8 +2,8 @@
 
 use lang\{ClassLoader, Reflection};
 
-class PackageInformation {
-  private $package, $flags;
+class PackageInformation extends TypeListing {
+  private $package;
 
   /** @param string $package */
   public function __construct($package, $flags) {
@@ -24,38 +24,7 @@ class PackageInformation {
       $i++;
     }
 
-    // Compile types into a custom order
-    $order= ['interface' => [], 'trait' => [], 'enum' => [], 'class' => []];
-    foreach ($this->package->types() as $type) {
-      $order[$type->kind()->name()][$type->name()]= $type;
-    }
-    foreach ($order as $type => $types) {
-      if (empty($types)) continue;
-      $separator= $out->separator($i);
-
-      ksort($types);
-      $i= 0;
-      foreach ($types as $type) {
-        if ($this->flags & Information::DOC) {
-          $out->separator(!$separator) || $separator= false;
-
-          $comment= $type->comment() ?? '(Undocumented)';
-          $p= strpos($comment, "\n\n");
-          $s= min(strpos($comment, '. ') ?: $p, strpos($comment, ".\n") ?: $p);
-
-          if (false === $s || $s > $p) {
-            $purpose= false === $p ? trim($comment) : substr($comment, 0, $p);
-          } else {
-            $purpose= substr($comment, 0, $s);
-          }
-          $out->documentation(str_replace(["\n", '  '], [' ', ' '], trim($purpose)), '  ');
-        }
-
-        $out->line('  ', $type->modifiers()->names(true).' '.$type->kind()->name().' '.$type->name());
-        $i++;
-      }
-    }
-
+    $this->list($out, $i, $this->package->types());
     $out->line('}');
   }
 }

--- a/src/main/php/xp/reflection/PackageInformation.class.php
+++ b/src/main/php/xp/reflection/PackageInformation.class.php
@@ -31,13 +31,15 @@ class PackageInformation {
     }
     foreach ($order as $type => $types) {
       if (empty($types)) continue;
-      if ($i) $out->line();
+      $separator= $out->separator($i);
 
       ksort($types);
       $i= 0;
       foreach ($types as $type) {
-        if ($this->flags & Information::DOC && ($comment= $type->comment())) {
-          $out->line();
+        if ($this->flags & Information::DOC) {
+          $out->separator(!$separator) || $separator= false;
+
+          $comment= $type->comment() ?? '(Undocumented)';
           $p= strpos($comment, "\n\n");
           $s= min(strpos($comment, '. ') ?: $p, strpos($comment, ".\n") ?: $p);
 

--- a/src/main/php/xp/reflection/ReflectRunner.class.php
+++ b/src/main/php/xp/reflection/ReflectRunner.class.php
@@ -73,6 +73,8 @@ class ReflectRunner {
       return 1;
     } else if (strstr($name, \xp::CLASS_FILE_EXT)) {
       $information= Information::forClass($cl->loadUri(realpath($name)), $flags);
+    } else if (is_dir($name)) {
+      $information= Information::forDirectory($name, $flags);
     } else if ($cl->providesClass($name)) {
       $information= Information::forClass($cl->loadClass($name), $flags);
     } else if ($cl->providesPackage($name)) {

--- a/src/main/php/xp/reflection/TypeListing.class.php
+++ b/src/main/php/xp/reflection/TypeListing.class.php
@@ -1,0 +1,39 @@
+<?php namespace xp\reflection;
+
+abstract class TypeListing {
+  protected $flags;
+
+  protected function list($out, $separator, $types) {
+    $order= ['interface' => [], 'trait' => [], 'enum' => [], 'class' => []];
+    foreach ($types as $type) {
+      $order[$type->kind()->name()][$type->name()]= $type;
+    }
+
+    foreach ($order as $type => $byName) {
+      if (empty($byName)) continue;
+      $line= $out->separator($separator);
+
+      ksort($byName);
+      $separator= 0;
+      foreach ($byName as $type) {
+        if ($this->flags & Information::DOC) {
+          $out->separator(!$line) || $line= false;
+
+          $comment= $type->comment() ?? '(Undocumented)';
+          $p= strpos($comment, "\n\n");
+          $s= min(strpos($comment, '. ') ?: $p, strpos($comment, ".\n") ?: $p);
+
+          if (false === $s || $s > $p) {
+            $purpose= false === $p ? trim($comment) : substr($comment, 0, $p);
+          } else {
+            $purpose= substr($comment, 0, $s);
+          }
+          $out->documentation(str_replace(["\n", '  '], [' ', ' '], trim($purpose)), '  ');
+        }
+
+        $out->line('  ', $type->modifiers()->names(true).' '.$type->kind()->name().' '.$type->name());
+        $separator++;
+      }
+    }
+  }
+}

--- a/src/main/php/xp/reflection/WithHighlighting.class.php
+++ b/src/main/php/xp/reflection/WithHighlighting.class.php
@@ -25,6 +25,14 @@ class WithHighlighting {
     $this->stream->write(preg_replace($this->patterns, $this->replacements, vsprintf($format, $args))."\n");
   }
 
+  public function separator($conditional) {
+    if ($conditional) {
+      $this->stream->write("\n");
+      return true;
+    }
+    return false;
+  }
+
   public function line(... $args) {
     $line= '';
     foreach ($args as $arg) {


### PR DESCRIPTION
This pull request changes the `reflect` subcommand to also accept directories. Supplying a directory will show packages and classes inside this directory. 

For example, if invoked in this library's root directory, the following output will be shown:

![carbon (1)](https://user-images.githubusercontent.com/696742/156747409-0b2b5dea-0a89-4ff4-9472-942e852615ec.png)

*(Image via https://carbon.now.sh/)*