### PR TITLE
Include type modifiers in ordering

### DIFF
--- a/src/main/php/xp/reflection/TypeListing.class.php
+++ b/src/main/php/xp/reflection/TypeListing.class.php
@@ -4,9 +4,17 @@ abstract class TypeListing {
   protected $flags;
 
   protected function list($out, $separator, $types) {
-    $order= ['interface' => [], 'trait' => [], 'enum' => [], 'class' => []];
+    $order= [
+      'public interface'      => [],
+      'public trait'          => [],
+      'public abstract enum'  => [],
+      'public enum'           => [],
+      'public abstract class' => [],
+      'public class'          => [],
+      'public final class'    => [],
+    ];
     foreach ($types as $type) {
-      $order[$type->kind()->name()][$type->name()]= $type;
+      $order[$type->modifiers()->names().' '.$type->kind()->name()][$type->name()]= $type;
     }
 
     foreach ($order as $type => $byName) {


### PR DESCRIPTION
This pull request separates abstract and final types from the rest when listing them. This will make it easier to spot extension points like abstract base classes, and make their display consistent with interfaces.

## Before:

```php
package peer.net {
  public class peer.net.Inet4Address
  public class peer.net.Inet6Address
  public abstract class peer.net.InetAddress
  // ...
}
```

## After:

```php
package peer.net {
  public abstract class peer.net.InetAddress

  public class peer.net.Inet4Address
  public class peer.net.Inet6Address
  // ...
}
```