### PR TITLE
Support `readonly` modifier on classes

### DIFF
--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -30,20 +30,29 @@ class Type implements Value {
     if (PHP_VERSION_ID < 70400) {
 
       // PHP 7.4 made type and member modifiers consistent. For versions before that,
-      // map PHP reflection modifiers to generic form
+      // map PHP reflection modifiers to generic form.
       //
       // @codeCoverageIgnoreStart
       $m= $this->reflect->getModifiers();
       $r= 0;
-      $m & \ReflectionClass::IS_EXPLICIT_ABSTRACT && $r |= Modifiers::IS_ABSTRACT;
-      $m & \ReflectionClass::IS_IMPLICIT_ABSTRACT && $r |= Modifiers::IS_ABSTRACT;
-      $m & \ReflectionClass::IS_FINAL && $r |= Modifiers::IS_FINAL;
+      $m & \ReflectionClass::IS_EXPLICIT_ABSTRACT && $r|= Modifiers::IS_ABSTRACT;
+      $m & \ReflectionClass::IS_IMPLICIT_ABSTRACT && $r|= Modifiers::IS_ABSTRACT;
+      $m & \ReflectionClass::IS_FINAL && $r|= Modifiers::IS_FINAL;
+      // @codeCoverageIgnoreEnd
+    } else if (PHP_VERSION_ID >= 80200) {
+
+      // PHP 8.2 introduced readonly classes, but its modifier bit is different from
+      // the one that properties use (65536 vs. 128), map this to generic form.
+      //
+      // @codeCoverageIgnoreStart
+      $r= $this->reflect->getModifiers();
+      $r & \ReflectionClass::IS_READONLY && $r^= \ReflectionClass::IS_READONLY | Modifiers::IS_READONLY;
       // @codeCoverageIgnoreEnd
     } else {
       $r= $this->reflect->getModifiers();
     }
 
-    $this->reflect->isInternal() && $r |= Modifiers::IS_NATIVE;
+    $this->reflect->isInternal() && $r|= Modifiers::IS_NATIVE;
     return new Modifiers($r);
   }
 

--- a/src/main/php/xp/reflection/ReflectRunner.class.php
+++ b/src/main/php/xp/reflection/ReflectRunner.class.php
@@ -93,7 +93,7 @@ class ReflectRunner {
       '/(class|enum|trait|interface|package|directory|function) (.+)/'      => "\e[34m\$1\e[0m \$2",
       '/(extends|implements) ([^ ]+)/'                                      => "\e[34m\$1\e[0m \$2",
       '/\b(var|int|string|float|array|iterable|object|void|static|self)\b/' => "\e[36m\$1\e[0m",
-      '/(public|private|protected|abstract|final|static) /'                 => "\e[1;35m\$1 \e[0m",
+      '/(public|private|protected|abstract|final|static|readonly) /'        => "\e[1;35m\$1 \e[0m",
       '/(\$[a-zA-Z0-9_]+)/'                                                 => "\e[1;31m\$1\e[0m",
       '/\'([^\']+)\'/'                                                      => "\e[32m'\$1'\e[0m"
     ]));

--- a/src/main/php/xp/reflection/TypeListing.class.php
+++ b/src/main/php/xp/reflection/TypeListing.class.php
@@ -1,5 +1,7 @@
 <?php namespace xp\reflection;
 
+use lang\reflection\Modifiers;
+
 abstract class TypeListing {
   protected $flags;
 
@@ -11,10 +13,13 @@ abstract class TypeListing {
       'public enum'           => [],
       'public abstract class' => [],
       'public class'          => [],
-      'public final class'    => [],
     ];
+
+    // List readonly and final types alongside others
+    $join= MODIFIER_READONLY | MODIFIER_FINAL;
     foreach ($types as $type) {
-      $order[$type->modifiers()->names().' '.$type->kind()->name()][$type->name()]= $type;
+      $names= Modifiers::namesOf($type->modifiers()->bits() & ~$join);
+      $order[$names.' '.$type->kind()->name()][$type->name()]= $type;
     }
 
     foreach ($order as $type => $byName) {

--- a/src/test/php/lang/reflection/unittest/ReflectionTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ReflectionTest.class.php
@@ -47,7 +47,7 @@ class ReflectionTest {
     Assert::instance(FromSyntaxTree::class, Reflection::annotations($versionId));
   }
 
-  #[Test, Values([80000, 80100])]
+  #[Test, Values([80000, 80100, 80200])]
   public function parser_for_php8($versionId) {
     Assert::instance(FromAttributes::class, Reflection::annotations($versionId));
   }

--- a/src/test/php/lang/reflection/unittest/TypeTest.class.php
+++ b/src/test/php/lang/reflection/unittest/TypeTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\reflection\{Kind, Modifiers, Annotations, Constants, Properties, Methods, Package};
 use lang\{ElementNotFoundException, Reflection, Enum, Runnable, XPClass, ClassLoader};
-use unittest\actions\VerifyThat;
+use unittest\actions\{VerifyThat, RuntimeVersion};
 use unittest\{Action, Assert, Before, Test};
 
 class TypeTest {
@@ -76,6 +76,12 @@ class TypeTest {
   public function native_modifiers() {
     $t= Reflection::of(\ReflectionClass::class);
     Assert::equals(new Modifiers('public native'), $t->modifiers());
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=8.2")')]
+  public function readonly_modifiers() {
+    $t= $this->declare('M_R', ['modifiers' => 'readonly']);
+    Assert::equals(new Modifiers('public readonly'), $t->modifiers());
   }
 
   #[Test]


### PR DESCRIPTION
Requested in #20

```bash
$ XP_RT=master xp -w 'readonly class T { } return \lang\Reflection::of(T::class)->modifiers()'
lang.reflection.Modifiers<public readonly>
```