### PR TITLE
Include type constants in `xp reflect` output

### DIFF
--- a/src/main/php/xp/reflection/ClassInformation.class.php
+++ b/src/main/php/xp/reflection/ClassInformation.class.php
@@ -12,10 +12,18 @@ class ClassInformation extends TypeInformation {
       $this->implements($this->type)
     );
 
+    $constants= iterator_to_array($this->type->constants());
     $properties= $this->partition($this->type->properties());
     $methods= $this->partition($this->type->methods());
 
     $section= 0;
+    if ($constants) {
+      $section++;
+      foreach ($constants as $constant) {
+        $this->member($out, $constant);
+      }
+    }
+
     if ($properties['class']) {
       $section++ && $out->line();
       foreach ($properties['class'] as $property) {

--- a/src/main/php/xp/reflection/EnumInformation.class.php
+++ b/src/main/php/xp/reflection/EnumInformation.class.php
@@ -12,6 +12,7 @@ class EnumInformation extends TypeInformation {
       $this->implements($this->type)
     );
 
+    $constants= iterator_to_array($this->type->constants());
     $properties= $this->partition($this->type->properties());
     $methods= $this->partition($this->type->methods());
 
@@ -21,6 +22,13 @@ class EnumInformation extends TypeInformation {
       if ($property->modifiers()->isStatic()) $props.= ', $'.$property->name();
     }
     $out->line('  ', substr($props, 2), ';');
+
+    if ($constants) {
+      $out->line();
+      foreach ($constants as $constant) {
+        $this->member($out, $constant);
+      }
+    }
 
     // List instance properties, if any
     if ($properties['instance']) {

--- a/src/main/php/xp/reflection/InterfaceInformation.class.php
+++ b/src/main/php/xp/reflection/InterfaceInformation.class.php
@@ -11,10 +11,18 @@ class InterfaceInformation extends TypeInformation {
       $this->parents($this->type)
     );
 
+    $constants= iterator_to_array($this->type->constants());
     $properties= $this->partition($this->type->properties());
     $methods= $this->partition($this->type->methods());
 
     $section= 0;
+    if ($constants) {
+      $section++;
+      foreach ($constants as $constant) {
+        $this->member($out, $constant);
+      }
+    }
+
     if ($properties['class']) {
       $section++ && $out->line();
       foreach ($properties['class'] as $property) {

--- a/src/main/php/xp/reflection/ReflectRunner.class.php
+++ b/src/main/php/xp/reflection/ReflectRunner.class.php
@@ -90,12 +90,12 @@ class ReflectRunner {
       Console::writeLine("\e[33m@", $source, "\e[0m");
     }
     $information->display(new WithHighlighting(Console::$out, [
-      '/(class|enum|trait|interface|package|directory|function) (.+)/'      => "\e[34m\$1\e[0m \$2",
-      '/(extends|implements) ([^ ]+)/'                                      => "\e[34m\$1\e[0m \$2",
-      '/\b(var|int|string|float|array|iterable|object|void|static|self)\b/' => "\e[36m\$1\e[0m",
-      '/(public|private|protected|abstract|final|static|readonly) /'        => "\e[1;35m\$1 \e[0m",
-      '/(\$[a-zA-Z0-9_]+)/'                                                 => "\e[1;31m\$1\e[0m",
-      '/\'([^\']+)\'/'                                                      => "\e[32m'\$1'\e[0m"
+      '/(class|enum|trait|interface|package|directory|function|const) (.+)/' => "\e[34m\$1\e[0m \$2",
+      '/(extends|implements) ([^ ]+)/'                                       => "\e[34m\$1\e[0m \$2",
+      '/\b(var|int|string|float|array|iterable|object|void|static|self)\b/'  => "\e[36m\$1\e[0m",
+      '/(public|private|protected|abstract|final|static|readonly|native) /'  => "\e[1;35m\$1 \e[0m",
+      '/(\$[a-zA-Z0-9_]+)/'                                                  => "\e[1;31m\$1\e[0m",
+      '/\'([^\']+)\'/'                                                       => "\e[32m'\$1'\e[0m"
     ]));
     return 0;
   }

--- a/src/main/php/xp/reflection/TraitInformation.class.php
+++ b/src/main/php/xp/reflection/TraitInformation.class.php
@@ -11,10 +11,19 @@ class TraitInformation extends TypeInformation {
       $this->type->name(),
       (($parent= $this->type->parent()) ? ' extends '.$parent->name() : '')
     );
+
+    $constants= iterator_to_array($this->type->constants());
     $properties= $this->partition($this->type->properties());
     $methods= $this->partition($this->type->methods());
 
     $section= 0;
+    if ($constants) {
+      $section++;
+      foreach ($constants as $constant) {
+        $this->member($out, $constant);
+      }
+    }
+
     if ($properties['class']) {
       $section++ && $out->line();
       foreach ($properties['class'] as $property) {


### PR DESCRIPTION
Example (shortened for brevity):

```bash
$ xp reflect ReflectionClass
@null
public native class ReflectionClass implements Stringable, Reflector {
  public const IS_IMPLICIT_ABSTRACT = 16
  public const IS_EXPLICIT_ABSTRACT = 64
  public const IS_FINAL = 32
  public const IS_READONLY = 65536

  public string $name
  ...
}
```

Note: Traits cannot have constants prior to PHP 8.2, see https://wiki.php.net/rfc/constants_in_traits