### PR TITLE
Add Reflection::type() to return type instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The entry point class is the `lang.Reflection` class. It can be constructed by p
 use lang\Reflection;
 use org\example\{Base, Inject, Fixture};
 
-$type= Reflection::of(Fixture::class);
+$type= Reflection::type(Fixture::class);
 
 $type->name();                // org.example.Fixture
 $type->literal();             // Fixture::class

--- a/src/main/php/lang/Reflection.class.php
+++ b/src/main/php/lang/Reflection.class.php
@@ -32,7 +32,33 @@ abstract class Reflection {
   }
 
   /**
-   * Creates a new reflection instance
+   * Returns a reflection type for a given argument.
+   *
+   * @param  string|object|lang.XPClass|lang.reflection.Type|ReflectionClass $arg
+   * @return lang.reflection.Type
+   * @throws lang.ClassNotFoundException
+   */
+  public static function type($arg) {
+    if ($arg instanceof XPClass) {
+      return new Type($arg->reflect());
+    } else if ($arg instanceof \ReflectionClass) {
+      return new Type($arg);
+    } else if ($arg instanceof Type) {
+      return $arg;
+    } else if (is_object($arg)) {
+      return new Type(new \ReflectionObject($arg));
+    } else {
+      try {
+        return new Type(new \ReflectionClass(strtr($arg,  '.', '\\')));
+      } catch (\ReflectionException $e) {
+        throw new ClassNotFoundException($arg, [ClassLoader::getDefault()]);
+      }
+    }
+  }
+
+  /**
+   * Creates a new reflection instance, which may either refer to a type
+   * or to a package.
    *
    * @param  string|object|lang.XPClass|lang.reflection.Type|ReflectionClass $arg
    * @return lang.reflection.Type|lang.reflection.Package

--- a/src/main/php/lang/Reflection.class.php
+++ b/src/main/php/lang/Reflection.class.php
@@ -49,7 +49,7 @@ abstract class Reflection {
       return new Type(new \ReflectionObject($arg));
     } else {
       try {
-        return new Type(new \ReflectionClass(strtr($arg,  '.', '\\')));
+        return new Type(new \ReflectionClass(strtr($arg, '.', '\\')));
       } catch (\ReflectionException $e) {
         throw new ClassNotFoundException($arg, [ClassLoader::getDefault()]);
       }
@@ -83,7 +83,7 @@ abstract class Reflection {
       }
 
       try {
-        return new Type(new \ReflectionClass(strtr($arg,  '.', '\\')));
+        return new Type(new \ReflectionClass(strtr($arg, '.', '\\')));
       } catch (\ReflectionException $e) {
         throw new ClassNotFoundException($name, [$cl]);
       }

--- a/src/test/php/lang/reflection/unittest/ReflectionTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ReflectionTest.class.php
@@ -1,45 +1,37 @@
 <?php namespace lang\reflection\unittest;
 
+use ReflectionClass, ReflectionObject;
 use lang\meta\{FromAttributes, FromSyntaxTree};
+use lang\reflection\Package;
 use lang\{Reflection, Type, ClassNotFoundException};
 use unittest\{Assert, Test, Values, Expect};
 
 class ReflectionTest {
 
-  #[Test]
-  public function of_class() {
-    Assert::equals(nameof($this), Reflection::of(self::class)->name());
+  /** @return iterable */
+  private function arguments() {
+    yield [self::class, 'class literal'];
+    yield [nameof($this), 'class name'];
+    yield [$this, 'instance'];
+    yield [Type::forName(self::class), 'type'];
+    yield [Reflection::of(self::class), 'reflection'];
+    yield [new ReflectionClass(self::class), 'reflection class'];
+    yield [new ReflectionObject($this), 'reflection object'];
+  }
+
+  #[Test, Values('arguments')]
+  public function of($argument) {
+    Assert::equals(nameof($this), Reflection::of($argument)->name());
+  }
+
+  #[Test, Values('arguments')]
+  public function type($argument) {
+    Assert::equals(nameof($this), Reflection::type($argument)->name());
   }
 
   #[Test]
-  public function of_name() {
-    Assert::equals(nameof($this), Reflection::of(nameof($this))->name());
-  }
-
-  #[Test]
-  public function of_type() {
-    Assert::equals(nameof($this), Reflection::of(Type::forName(self::class))->name());
-  }
-
-  #[Test]
-  public function of_reflection() {
-    $t= Reflection::of(self::class);
-    Assert::equals($t, Reflection::of($t));
-  }
-
-  #[Test]
-  public function of_reflection_class() {
-    Assert::equals(nameof($this), Reflection::of(new \ReflectionClass(self::class))->name());
-  }
-
-  #[Test]
-  public function of_reflection_object() {
-    Assert::equals(nameof($this), Reflection::of(new \ReflectionObject($this))->name());
-  }
-
-  #[Test]
-  public function of_instance() {
-    Assert::equals(nameof($this), Reflection::of($this)->name());
+  public function of_package_name() {
+    Assert::instance(Package::class, Reflection::of('lang.reflection.unittest'));
   }
 
   #[Test, Values([70000, 70100, 70200, 70300, 70400])]
@@ -55,5 +47,15 @@ class ReflectionTest {
   #[Test, Expect(ClassNotFoundException::class)]
   public function of_non_existant() {
     Reflection::of('non.existant.Type');
+  }
+
+  #[Test, Expect(ClassNotFoundException::class)]
+  public function type_existant() {
+    Reflection::type('non.existant.Type');
+  }
+
+  #[Test, Expect(ClassNotFoundException::class)]
+  public function type_given_package_name() {
+    Assert::instance(Package::class, Reflection::type('lang.reflection.unittest'));
   }
 }


### PR DESCRIPTION
Unlike `Reflection::of()`, which includes code to handle package names given to it, the `type()` method can be used anywhere we only want a type