### PR TITLE
Add support for named annotation arguments in PHP 7

### DIFF
--- a/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
@@ -220,6 +220,11 @@ class AnnotationTest {
     Assert::instance(Annotated::class, $t->annotation(Annotated::class)->newInstance());
   }
 
+  #[Test, Values(['#[Parameterized(1, 2)]', '#[Parameterized(a: 1, b: 2)]', '#[Parameterized(b: 2, a: 1)]'])]
+  public function parameterized_instantiation($declaration) {
+    $t= $this->declare('{}', $declaration);
+    Assert::equals(new Parameterized(1, 2), $t->annotation(Parameterized::class)->newInstance());
+  }
 
   #[Test, Values(eval: '[[Annotated::class], [new XPClass(Annotated::class)]]')]
   public function is($type) {

--- a/src/test/php/lang/reflection/unittest/Parameterized.class.php
+++ b/src/test/php/lang/reflection/unittest/Parameterized.class.php
@@ -1,0 +1,10 @@
+<?php namespace lang\reflection\unittest;
+
+class Parameterized {
+  private $a, $b;
+
+  public function __construct($a, $b) {
+    $this->a= $a;
+    $this->b= $b;
+  }
+}


### PR DESCRIPTION
Before, if named arguments were used, this would result in *Uncaught exception: Error (Cannot unpack array with string keys)* when calling `Annotation::newInstance()`.

See also #16 