### PR TITLE
Implement Annotations::all() with returns all annotation of a given type

### DIFF
--- a/src/main/php/lang/reflection/Annotations.class.php
+++ b/src/main/php/lang/reflection/Annotations.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\reflection;
 
 use IteratorAggregate, Traversable;
+use lang\XPClass;
 
 /**
  * Type and member annotations enumeration and lookup
@@ -41,5 +42,25 @@ class Annotations implements IteratorAggregate {
   public function type($type) {
     $t= strtr($type, '.', '\\');
     return isset($this->annotations[$t]) ? new Annotation($t, $this->annotations[$t]) : null;
+  }
+
+  /**
+   * Returns all annotation of a given type
+   *
+   * @param  string|lang.XPClass|lang.reflection.Type $type
+   * @return iterable
+   */
+  public function all($type) {
+    if ($type instanceof Type || $type instanceof XPClass) {
+      $compare= $type->literal();
+    } else {
+      $compare= strtr($type, '.', '\\');
+    }
+
+    foreach ($this->annotations as $type => $arguments) {
+      if ($type === $compare || is_subclass_of($type, $compare)) {
+        yield $type => new Annotation($type, $arguments);
+      }
+    }
   }
 }

--- a/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
@@ -323,9 +323,15 @@ class AnnotationTest {
   }
 
   #[Test]
-  public function all_of_direct() {
+  public function all_of_annotated() {
     $t= $this->declare('{}', '#[Annotated, Parameterized(1, 2), Error(Fixture::class)]');
     $this->assertAnnotations([Annotated::class => []], $t->annotations()->all(Annotated::class));
+  }
+
+  #[Test]
+  public function all_of_error() {
+    $t= $this->declare('{}', '#[Annotated, Parameterized(1, 2), Error(Fixture::class)]');
+    $this->assertAnnotations([Error::class => [Fixture::class]], $t->annotations()->all(Error::class));
   }
 
   #[Test, Values('types')]

--- a/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\reflection\unittest;
 
-use lang\XPClass;
 use lang\reflection\Annotation;
+use lang\{XPClass, Reflection};
 use unittest\{Assert, Test, Values};
 
 class AnnotationTest {
@@ -80,6 +80,13 @@ class AnnotationTest {
     yield ['#[Annotated(eval: "new Fixture()")]', [new Fixture()]];
     yield ['#[Annotated(eval: "Fixture::\$DEFAULT")]', [Fixture::$DEFAULT]];
     yield ['#[Annotated(eval: "self::\$member")]', ['Test']];
+  }
+
+  /** @return iterable */
+  private function types() {
+    yield [Declared::class];
+    yield [new XPClass(Declared::class)];
+    yield [Reflection::type(Declared::class)];
   }
 
   #[Test, Values('scalars')]
@@ -316,11 +323,17 @@ class AnnotationTest {
   }
 
   #[Test]
-  public function all_of() {
+  public function all_of_direct() {
+    $t= $this->declare('{}', '#[Annotated, Parameterized(1, 2), Error(Fixture::class)]');
+    $this->assertAnnotations([Annotated::class => []], $t->annotations()->all(Annotated::class));
+  }
+
+  #[Test, Values('types')]
+  public function all_of($type) {
     $t= $this->declare('{}', '#[Annotated, Parameterized(1, 2), Error(Fixture::class)]');
     $this->assertAnnotations(
       [Annotated::class => [], Parameterized::class => [1, 2]],
-      $t->annotations()->all(Declared::class)
+      $t->annotations()->all($type)
     );
-  } 
+  }
 }

--- a/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
@@ -313,5 +313,14 @@ class AnnotationTest {
       'A33d3567738fa0159cd21f46db6f5d219',
       $t->annotation(Annotated::class)->hashCode()
     );
+  }
+
+  #[Test]
+  public function all_of() {
+    $t= $this->declare('{}', '#[Annotated, Parameterized(1, 2), Error(Fixture::class)]');
+    $this->assertAnnotations(
+      [Annotated::class => [], Parameterized::class => [1, 2]],
+      $t->annotations()->all(Declared::class)
+    );
   } 
 }

--- a/src/test/php/lang/reflection/unittest/Declared.class.php
+++ b/src/test/php/lang/reflection/unittest/Declared.class.php
@@ -1,5 +1,5 @@
 <?php namespace lang\reflection\unittest;
 
-class Annotated implements Declared {
+interface Declared {
   
 }

--- a/src/test/php/lang/reflection/unittest/Parameterized.class.php
+++ b/src/test/php/lang/reflection/unittest/Parameterized.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\reflection\unittest;
 
-class Parameterized {
+class Parameterized implements Declared {
   private $a, $b;
 
   public function __construct($a, $b) {


### PR DESCRIPTION
Given the following annotations:

```php
interface Prerequisite { }

class Runtime implements Prerequisite { /* ... */ }

class VerifyThat implements Prerequisite { /* ... */ }
```

...and the following type:

```php
#[Runtime(php: '^8.1', VerifyThat(eval: 'class_exists(Calculator::class)'), Author('Timm')]
class CalculatorTest {
  /* ... */
}
```

...the following will return both *Runtime* and *VerifyThat* but not *Author*:

```php
$prerequisites= $type->annotations()->all(Prerequisite::class);
```