### PR TITLE
Invocation exceptions consistency

### DIFF
--- a/src/main/php/lang/reflection/Annotation.class.php
+++ b/src/main/php/lang/reflection/Annotation.class.php
@@ -47,7 +47,7 @@ class Annotation implements Value {
    */
   public function newInstance() {
     try {
-      $pass= PHP_VERSION_ID < 80000 && is_string(key($this->arguments))
+      $pass= PHP_VERSION_ID < 80000 && $this->arguments
         ? Routine::pass(new ReflectionMethod($this->type, '__construct'), $this->arguments)
         : $this->arguments
       ;

--- a/src/main/php/lang/reflection/Constructor.class.php
+++ b/src/main/php/lang/reflection/Constructor.class.php
@@ -36,22 +36,8 @@ class Constructor extends Routine implements Instantiation {
    * @throws lang.reflection.CannotInstantiate
    */
   public function newInstance(array $args= [], $context= null) {
-
-    // Support named arguments for PHP 7.X
-    if (PHP_VERSION_ID < 80000 && is_string(key($args))) {
-      $pass= [];
-      foreach ($this->reflect->getParameters() as $param) {
-        $pass[]= $args[$param->name] ?? ($param->isOptional() ? $param->getDefaultValue() : null);
-        unset($args[$param->name]);
-      }
-      if ($args) {
-        throw new CannotInstantiate($this->class->name, new Error('Unknown named parameter $'.key($args)));
-      }
-    } else {
-      $pass= $args;
-    }
-
     try {
+      $pass= PHP_VERSION_ID < 80000 ? self::pass($this->reflect, $args) : $args;
 
       // Workaround for non-public constructors: Set accessible, then manually
       // invoke after creating an instance without invoking the constructor.

--- a/src/main/php/lang/reflection/Constructor.class.php
+++ b/src/main/php/lang/reflection/Constructor.class.php
@@ -37,7 +37,7 @@ class Constructor extends Routine implements Instantiation {
    */
   public function newInstance(array $args= [], $context= null) {
     try {
-      $pass= PHP_VERSION_ID < 80000 ? self::pass($this->reflect, $args) : $args;
+      $pass= PHP_VERSION_ID < 80000 && $args ? self::pass($this->reflect, $args) : $args;
 
       // Workaround for non-public constructors: Set accessible, then manually
       // invoke after creating an instance without invoking the constructor.

--- a/src/main/php/lang/reflection/Initializer.class.php
+++ b/src/main/php/lang/reflection/Initializer.class.php
@@ -56,7 +56,7 @@ class Initializer extends Routine implements Instantiation {
     if (null === $this->function) return $instance;
 
     try {
-      $pass= PHP_VERSION_ID < 80000 ? Routine::pass($this->reflect, $args) : $args;
+      $pass= PHP_VERSION_ID < 80000 && $args ? Routine::pass($this->reflect, $args) : $args;
       $this->function->__invoke($instance, $pass, $context);
       return $instance;
     } catch (ArgumentCountError $e) {

--- a/src/main/php/lang/reflection/Initializer.class.php
+++ b/src/main/php/lang/reflection/Initializer.class.php
@@ -76,6 +76,8 @@ class Initializer extends Routine implements Instantiation {
       throw new CannotInstantiate($this->class->name, $e);
     } catch (TypeError $e) {
       throw new CannotInstantiate($this->class->name, $e);
+    } catch (ReflectionException $e) {
+      throw new CannotInstantiate($this->class->name, $e);
     } catch (Throwable $e) {
 
       // This really should be an ArgumentCountError...

--- a/src/main/php/lang/reflection/Initializer.class.php
+++ b/src/main/php/lang/reflection/Initializer.class.php
@@ -1,5 +1,6 @@
 <?php namespace lang\reflection;
 
+use ArgumentCountError, ReflectionException, Throwable, TypeError;
 use lang\Reflection;
 
 /**
@@ -48,15 +49,20 @@ class Initializer extends Routine implements Instantiation {
   public function newInstance(array $args= [], $context= null) {
     try {
       $instance= $this->class->newInstanceWithoutConstructor();
-    } catch (\ReflectionException $e) {
+    } catch (ReflectionException $e) {
       throw new CannotInstantiate($this->class->name, $e);
     }
 
     if (null === $this->function) return $instance;
+
     try {
       $this->function->__invoke($instance, $args, $context);
       return $instance;
-    } catch (\Throwable $e) {
+    } catch (ArgumentCountError $e) {
+      throw new CannotInstantiate($this->reflect->name, $e);
+    } catch (TypeError $e) {
+      throw new CannotInstantiate($this->reflect->name, $e);
+    } catch (Throwable $e) {
       throw new InvocationFailed($this, $e);
     }
   }

--- a/src/main/php/lang/reflection/Initializer.class.php
+++ b/src/main/php/lang/reflection/Initializer.class.php
@@ -55,21 +55,8 @@ class Initializer extends Routine implements Instantiation {
 
     if (null === $this->function) return $instance;
 
-    // Support named arguments for PHP 7.X
-    if (PHP_VERSION_ID < 80000 && is_string(key($args))) {
-      $pass= [];
-      foreach ($this->reflect->getParameters() as $param) {
-        $pass[]= $args[$param->name] ?? ($param->isOptional() ? $param->getDefaultValue() : null);
-        unset($args[$param->name]);
-      }
-      if ($args) {
-        throw new CannotInstantiate($this->class->name, new Error('Unknown named parameter $'.key($args)));
-      }
-    } else {
-      $pass= $args;
-    }
-
     try {
+      $pass= PHP_VERSION_ID < 80000 ? Routine::pass($this->reflect, $args) : $args;
       $this->function->__invoke($instance, $pass, $context);
       return $instance;
     } catch (ArgumentCountError $e) {

--- a/src/main/php/lang/reflection/Method.class.php
+++ b/src/main/php/lang/reflection/Method.class.php
@@ -61,7 +61,7 @@ class Method extends Routine {
     }
 
     try {
-      $pass= PHP_VERSION_ID < 80000 ? self::pass($this->reflect, $args) : $args;
+      $pass= PHP_VERSION_ID < 80000 && $args ? self::pass($this->reflect, $args) : $args;
 
       // PHP 7.0 still had warnings for arguments
       if (PHP_VERSION_ID < 70100 && sizeof($pass) < $this->reflect->getNumberOfRequiredParameters()) {

--- a/src/main/php/lang/reflection/Method.class.php
+++ b/src/main/php/lang/reflection/Method.class.php
@@ -53,7 +53,7 @@ class Method extends Routine {
 
     // Only allow invoking non-public methods when given a compatible context
     if (!$this->reflect->isPublic()) {
-      if ($context && Reflection::of($context)->is($this->reflect->class)) {
+      if ($context && Reflection::type($context)->is($this->reflect->class)) {
         $this->reflect->setAccessible(true);
       } else {
         throw new CannotInvoke($this, new ReflectionException('Trying to invoke non-public method'));
@@ -62,7 +62,7 @@ class Method extends Routine {
 
     try {
 
-      // Support named arguments for PHP 7
+      // Support named arguments for PHP 7.X
       if (PHP_VERSION_ID < 80000 && is_string(key($args))) {
         $pass= [];
         foreach ($this->reflect->getParameters() as $param) {

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -238,7 +238,9 @@ class Type implements Value {
     } catch (ReflectionException $e) {
       throw new CannotInstantiate($this->reflect->name, $e);
     } catch (Throwable $e) {
-      if ($this->reflect->isInstantiable() && $constructor) {
+      if (0 === strpos($e->getMessage(), 'Unknown named parameter $')) {
+        throw new CannotInstantiate($this->reflect->name, $e);
+      } else if ($this->reflect->isInstantiable() && $constructor) {
         throw new InvocationFailed($this->constructor(), $e);
       } else {
         throw new CannotInstantiate($this->reflect->name);

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -212,7 +212,22 @@ class Type implements Value {
     $constructor= $this->reflect->hasMethod('__construct');
     try {
       if ($constructor) {
-        return $this->reflect->newInstanceArgs($args);
+
+        // Support named arguments for PHP 7.X
+        if (PHP_VERSION_ID < 80000 && is_string(key($args))) {
+          $pass= [];
+          foreach ($constructor->getParameters() as $param) {
+            $pass[]= $args[$param->name] ?? ($param->isOptional() ? $param->getDefaultValue() : null);
+            unset($args[$param->name]);
+          }
+          if ($args) {
+            throw new ReflectionException('Unknown named parameter $'.key($args));
+          }
+        } else {
+          $pass= $args;
+        }
+
+        return $this->reflect->newInstanceArgs($pass);
       } else {
         return $this->reflect->newInstance();
       }

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -212,7 +212,7 @@ class Type implements Value {
     $constructor= $this->reflect->hasMethod('__construct');
     try {
       if ($constructor) {
-        $pass= PHP_VERSION_ID < 80000 ? Routine::pass($constructor, $args) : $args;
+        $pass= PHP_VERSION_ID < 80000 && $args ? Routine::pass($constructor, $args) : $args;
         return $this->reflect->newInstanceArgs($pass);
       } else {
         return $this->reflect->newInstance();

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -212,21 +212,7 @@ class Type implements Value {
     $constructor= $this->reflect->hasMethod('__construct');
     try {
       if ($constructor) {
-
-        // Support named arguments for PHP 7.X
-        if (PHP_VERSION_ID < 80000 && is_string(key($args))) {
-          $pass= [];
-          foreach ($constructor->getParameters() as $param) {
-            $pass[]= $args[$param->name] ?? ($param->isOptional() ? $param->getDefaultValue() : null);
-            unset($args[$param->name]);
-          }
-          if ($args) {
-            throw new ReflectionException('Unknown named parameter $'.key($args));
-          }
-        } else {
-          $pass= $args;
-        }
-
+        $pass= PHP_VERSION_ID < 80000 ? Routine::pass($constructor, $args) : $args;
         return $this->reflect->newInstanceArgs($pass);
       } else {
         return $this->reflect->newInstance();

--- a/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\reflection\unittest;
 
-use lang\reflection\Annotation;
-use lang\{XPClass, Reflection};
-use unittest\{Assert, Test, Values};
+use lang\reflection\{Annotation, InvocationFailed, CannotInstantiate};
+use lang\{XPClass, Reflection, IllegalStateException};
+use unittest\{Assert, Expect, Test, Values};
 
 class AnnotationTest {
   use TypeDefinition;
@@ -231,6 +231,30 @@ class AnnotationTest {
   public function parameterized_instantiation($declaration) {
     $t= $this->declare('{}', $declaration);
     Assert::equals(new Parameterized(1, 2), $t->annotation(Parameterized::class)->newInstance());
+  }
+
+  #[Test, Expect(CannotInstantiate::class)]
+  public function missing_parameter() {
+    $t= $this->declare('{}', '#[Parameterized(1)]');
+    $t->annotation(Parameterized::class)->newInstance();
+  }
+
+  #[Test, Expect(CannotInstantiate::class)]
+  public function invalid_parameter_type() {
+    $t= $this->declare('{}', '#[Parameterized("test")]');
+    $t->annotation(Parameterized::class)->newInstance();
+  }
+
+  #[Test, Expect(CannotInstantiate::class)]
+  public function unknown_named_parameter() {
+    $t= $this->declare('{}', '#[Parameterized(c: 3)]');
+    $t->annotation(Parameterized::class)->newInstance();
+  }
+
+  #[Test, Expect(InvocationFailed::class)]
+  public function instantiation_failed() {
+    $t= $this->declare('{}', '#[Parameterized(1, -1)]');
+    $t->annotation(Parameterized::class)->newInstance();
   }
 
   #[Test, Values(eval: '[[Annotated::class], [new XPClass(Annotated::class)]]')]

--- a/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
@@ -259,4 +259,22 @@ class InstantiationTest {
     }');
     Assert::equals([1, 3], $t->newInstance(...['b' => 3])->values);
   }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")'), Expect(CannotInstantiate::class)]
+  public function excess_named_arguments_raise_error_for_newInstance() {
+    $t= $this->declare('{
+      public $values;
+      public function __construct($a, $b) { $this->values= [$a, $b]; }
+    }');
+    $t->newInstance(...['b' => 2, 'a' => 1, 'extra' => 3]);
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")'), Expect(CannotInstantiate::class)]
+  public function unknown_named_arguments_raise_error_for_newInstance() {
+    $t= $this->declare('{
+      public $values;
+      public function __construct($a, $b) { $this->values= [$a, $b]; }
+    }');
+    $t->newInstance(...['c' => 3]);
+  }
 }

--- a/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
@@ -114,12 +114,12 @@ class InstantiationTest {
 
   #[Test, Expect(CannotInstantiate::class)]
   public function interfaces_cannot_be_instantiated() {
-    Reflection::of(Runnable::class)->newInstance();
+    Reflection::type(Runnable::class)->newInstance();
   }
 
   #[Test, Expect(CannotInstantiate::class)]
   public function abstract_classes_cannot_be_instantiated() {
-    Reflection::of(CommandLine::class)->newInstance();
+    Reflection::type(CommandLine::class)->newInstance();
   }
 
   #[Test]
@@ -177,7 +177,7 @@ class InstantiationTest {
 
   #[Test]
   public function instantiate_on_interface() {
-    Assert::null(Reflection::of(Runnable::class)->initializer(null));
+    Assert::null(Reflection::type(Runnable::class)->initializer(null));
   }
 
   #[Test]

--- a/src/test/php/lang/reflection/unittest/Parameterized.class.php
+++ b/src/test/php/lang/reflection/unittest/Parameterized.class.php
@@ -1,9 +1,16 @@
 <?php namespace lang\reflection\unittest;
 
+use lang\IllegalArgumentException;
+
 class Parameterized implements Declared {
   private $a, $b;
 
-  public function __construct($a, $b) {
+  /** @throws lang.IllegalArgumentException */
+  public function __construct(int $a, int $b) {
+    if ($b < $a) {
+      throw new IllegalArgumentException('b may not be smaller than a');
+    }
+
     $this->a= $a;
     $this->b= $b;
   }


### PR DESCRIPTION
This pull request addresses inconsistencies with exceptions raised by invocations:

* We should catch `CannotInvoke` or `CannotInstantiate` if prerequisites to the invocation fail - e.g. missing arguments, unknown named arguments, argument type mismatches. The underlying method or constructor **has not run**.
* We should catch `InvocationFailed` if the invocation itself raises an exception

## TODO

* [x] Instantiating types: `Type::newInstance()`
* [x] Instantiating annotations: `Annotation::newInstance()`
* [x] Using constructors: `Constructor::newInstance()`
* [x] Using initializers: `Initializer::newInstance()`