### PR TITLE
Prefer PHP 8 attributes over xp::$meta

### DIFF
--- a/src/main/php/lang/Reflection.class.php
+++ b/src/main/php/lang/Reflection.class.php
@@ -22,13 +22,10 @@ use lang\{ClassLoader, ClassNotFoundException};
 abstract class Reflection {
   private static $meta= null;
 
-  public static function annotations($version) {
-    return $version >= 80000 ? new FromAttributes() : new FromSyntaxTree();
-  }
 
   /** Lazy-loads meta information extraction */
   public static function meta(): MetaInformation {
-    return self::$meta ?? self::$meta= new MetaInformation(self::annotations(PHP_VERSION_ID));
+    return self::$meta ?? self::$meta= new MetaInformation();
   }
 
   /**

--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -9,26 +9,16 @@ Use lang\reflection\Modifiers;
 class MetaInformation {
   private $annotations;
 
-  public function __construct($annotations) {
-    $this->annotations= $annotations;
+  public function __construct($annotations= null) {
+    $this->annotations= $annotations ?? self::annotations(PHP_VERSION_ID);
+  }
+
+  public static function annotations($version) {
+    return $version >= 80000 ? new FromAttributes() : new FromSyntaxTree();
   }
 
   public function evaluate($reflect, $code) {
     return $this->annotations->evaluate($reflect, $code);
-  }
-
-  /**
-   * Constructs annotations from meta information
-   *
-   * @param  [:var] $meta
-   * @return [:var]
-   */
-  private function annotations($meta) {
-    $r= [];
-    foreach ($meta[DETAIL_ANNOTATIONS] as $name => $value) {
-      $r[$meta[DETAIL_TARGET_ANNO][$name] ?? $name]= (array)$value;
-    }
-    return $r;
   }
 
   /**
@@ -64,11 +54,7 @@ class MetaInformation {
    * @return [:var[]]
    */
   public function typeAnnotations($reflect) {
-    if ($meta= \xp::$meta[strtr($reflect->name, '\\', '.')]['class'] ?? null) {
-      return $this->annotations($meta);
-    } else {
-      return $this->annotations->ofType($reflect);
-    }
+    return $this->annotations->ofType($reflect);
   }
 
   /**
@@ -94,12 +80,7 @@ class MetaInformation {
    * @return [:var[]]
    */
   public function constantAnnotations($reflect) {
-    $c= strtr($reflect->getDeclaringClass()->name, '\\', '.');
-    if ($meta= \xp::$meta[$c][2][$reflect->name] ?? null) {
-      return $this->annotations($meta);
-    } else {
-      return $this->annotations->ofConstant($reflect);
-    }
+    return $this->annotations->ofConstant($reflect);
   }
 
   /**
@@ -126,12 +107,7 @@ class MetaInformation {
    * @return [:var[]]
    */
   public function propertyAnnotations($reflect) {
-    $c= strtr($reflect->getDeclaringClass()->name, '\\', '.');
-    if ($meta= \xp::$meta[$c][0][$reflect->name] ?? null) {
-      return $this->annotations($meta);
-    } else {
-      return $this->annotations->ofProperty($reflect);
-    }
+    return $this->annotations->ofProperty($reflect);
   }
 
   /**
@@ -174,12 +150,7 @@ class MetaInformation {
    * @return [:var[]]
    */
   public function methodAnnotations($reflect) {
-    $c= strtr($reflect->getDeclaringClass()->name, '\\', '.');
-    if ($meta= \xp::$meta[$c][1][$reflect->name] ?? null) {
-      return $this->annotations($meta);
-    } else {
-      return $this->annotations->ofMethod($reflect);
-    }
+    return $this->annotations->ofMethod($reflect);
   }
 
   /**
@@ -239,16 +210,6 @@ class MetaInformation {
    * @return [:var[]]
    */
   public function parameterAnnotations($method, $reflect) {
-    $c= strtr($method->getDeclaringClass()->name, '\\', '.');
-    if ($target= \xp::$meta[$c][1][$method->name][DETAIL_TARGET_ANNO] ?? null) {
-      if ($param= $target['$'.$reflect->name] ?? null) {
-        $r= [];
-        foreach ($param as $name => $value) {
-          $r[$target[$name] ?? $name]= (array)$value;
-        }
-        return $r;
-      }
-    }
     return $this->annotations->ofParameter($method, $reflect);
   }
 

--- a/src/test/php/lang/reflection/unittest/Fixture.class.php
+++ b/src/test/php/lang/reflection/unittest/Fixture.class.php
@@ -1,13 +1,22 @@
 <?php namespace lang\reflection\unittest;
 
+#[Annotated('test')]
 class Fixture {
+
+  #[Annotated('test')]
   const TEST = 'test';
 
+  #[Annotated('test')]
   public static $DEFAULT = null;
+
   private $value;
 
   /** @param var */
-  public function __construct($value= null) {
+  #[Annotated('test')]
+  public function __construct(
+    #[Annotated('test')]
+    $value= null
+  ) {
     $this->value= $value;
   }
 

--- a/src/test/php/lang/reflection/unittest/MetaInformationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/MetaInformationTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\reflection\unittest;
 
-use lang\meta\MetaInformation;
+use ReflectionClass;
+use lang\meta\{MetaInformation, FromAttributes, FromSyntaxTree};
 use unittest\{Assert, Before, After, Test};
 
 class MetaInformationTest {
@@ -37,12 +38,22 @@ class MetaInformationTest {
         ]
       ]
     ];
-    $this->reflect= new \ReflectionClass(Fixture::class);
+    $this->reflect= new ReflectionClass(Fixture::class);
   }
 
   #[After]
   public function finalize() {
     unset(\xp::$meta['lang.reflection.unittest.Fixture']);
+  }
+
+  #[Test, Values([70000, 70100, 70200, 70300, 70400])]
+  public function parser_for_php7($versionId) {
+    Assert::instance(FromSyntaxTree::class, MetaInformation::annotations($versionId));
+  }
+
+  #[Test, Values([80000, 80100, 80200, 80300])]
+  public function parser_for_php8($versionId) {
+    Assert::instance(FromAttributes::class, MetaInformation::annotations($versionId));
   }
 
   #[Test]

--- a/src/test/php/lang/reflection/unittest/ReflectionTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ReflectionTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace lang\reflection\unittest;
 
 use ReflectionClass, ReflectionObject;
-use lang\meta\{FromAttributes, FromSyntaxTree};
 use lang\reflection\Package;
 use lang\{Reflection, Type, ClassNotFoundException};
 use unittest\{Assert, Test, Values, Expect};
@@ -32,16 +31,6 @@ class ReflectionTest {
   #[Test]
   public function of_package_name() {
     Assert::instance(Package::class, Reflection::of('lang.reflection.unittest'));
-  }
-
-  #[Test, Values([70000, 70100, 70200, 70300, 70400])]
-  public function parser_for_php7($versionId) {
-    Assert::instance(FromSyntaxTree::class, Reflection::annotations($versionId));
-  }
-
-  #[Test, Values([80000, 80100, 80200])]
-  public function parser_for_php8($versionId) {
-    Assert::instance(FromAttributes::class, Reflection::annotations($versionId));
   }
 
   #[Test, Expect(ClassNotFoundException::class)]


### PR DESCRIPTION
This would enable us to no longer have to emit annotations in `xp::$meta` for PHP 8, but instead use the native syntax.