### PR TITLE
Add lang.reflection.CannotInstantiate::type() accessor

### DIFF
--- a/src/main/php/lang/reflection/Annotation.class.php
+++ b/src/main/php/lang/reflection/Annotation.class.php
@@ -53,16 +53,16 @@ class Annotation implements Value {
       ;
       return new $this->type(...$pass);
     } catch (ArgumentCountError $e) {
-      throw new CannotInstantiate($this->type, $e);
+      throw new CannotInstantiate(new Type(new ReflectionClass($this->type)), $e);
     } catch (TypeError $e) {
-      throw new CannotInstantiate($this->type, $e);
+      throw new CannotInstantiate(new Type(new ReflectionClass($this->type)), $e);
     } catch (ReflectionException $e) {
-      throw new CannotInstantiate($this->type, $e);
+      throw new CannotInstantiate(new Type(new ReflectionClass($this->type)), $e);
     } catch (Throwable $e) {
 
       // This really should be an ArgumentCountError...
       if (0 === strpos($e->getMessage(), 'Unknown named parameter $')) {
-        throw new CannotInstantiate($this->type, $e);
+        throw new CannotInstantiate(new Type(new ReflectionClass($this->type)), $e);
       }
 
       throw new InvocationFailed(new Constructor(new ReflectionClass($this->type)), $e);

--- a/src/main/php/lang/reflection/Annotation.class.php
+++ b/src/main/php/lang/reflection/Annotation.class.php
@@ -53,16 +53,16 @@ class Annotation implements Value {
       ;
       return new $this->type(...$pass);
     } catch (ArgumentCountError $e) {
-      throw new CannotInstantiate(new Type(new ReflectionClass($this->type)), $e);
+      throw new CannotInstantiate($this->type, $e);
     } catch (TypeError $e) {
-      throw new CannotInstantiate(new Type(new ReflectionClass($this->type)), $e);
+      throw new CannotInstantiate($this->type, $e);
     } catch (ReflectionException $e) {
-      throw new CannotInstantiate(new Type(new ReflectionClass($this->type)), $e);
+      throw new CannotInstantiate($this->type, $e);
     } catch (Throwable $e) {
 
       // This really should be an ArgumentCountError...
       if (0 === strpos($e->getMessage(), 'Unknown named parameter $')) {
-        throw new CannotInstantiate(new Type(new ReflectionClass($this->type)), $e);
+        throw new CannotInstantiate($this->type, $e);
       }
 
       throw new InvocationFailed(new Constructor(new ReflectionClass($this->type)), $e);

--- a/src/main/php/lang/reflection/CannotInstantiate.class.php
+++ b/src/main/php/lang/reflection/CannotInstantiate.class.php
@@ -1,15 +1,28 @@
 <?php namespace lang\reflection;
 
+use ReflectionClass;
 use lang\XPException;
 
 /** Indicates instantiating a type failed because of preconditions */
 class CannotInstantiate extends XPException {
   private $type;
 
-  /** Creates a new instance */
-  public function __construct(Type $type, $cause= null) {
-    parent::__construct('Cannot instantiate '.$type->name(), $cause);
-    $this->type= $type;
+  /**
+   * Creates a new instance
+   *
+   * @param  string|ReflectionClass|lang.reflection.Type $type
+   * @param  ?lang.Throwable $cause
+   */
+  public function __construct($type, $cause= null) {
+    if ($type instanceof Type) {
+      $this->type= $type;
+    } else if ($type instanceof ReflectionClass) {
+      $this->type= new Type($type);
+    } else {
+      $this->type= new Type(new ReflectionClass($type));
+    }
+
+    parent::__construct('Cannot instantiate '.$this->type->name(), $cause);
   }
 
   /** Returns the type */

--- a/src/main/php/lang/reflection/CannotInstantiate.class.php
+++ b/src/main/php/lang/reflection/CannotInstantiate.class.php
@@ -4,5 +4,15 @@ use lang\XPException;
 
 /** Indicates instantiating a type failed because of preconditions */
 class CannotInstantiate extends XPException {
+  private $type;
+
+  /** Creates a new instance */
+  public function __construct(Type $type, $cause= null) {
+    parent::__construct('Cannot instantiate '.$type->name(), $cause);
+    $this->type= $type;
+  }
+
+  /** Returns the type */
+  public function type(): Type { return $this->type; }
 
 }

--- a/src/main/php/lang/reflection/Constructor.class.php
+++ b/src/main/php/lang/reflection/Constructor.class.php
@@ -52,16 +52,16 @@ class Constructor extends Routine implements Instantiation {
 
       return $this->class->newInstanceArgs($pass);
     } catch (ArgumentCountError $e) {
-      throw new CannotInstantiate(new Type($this->class), $e);
+      throw new CannotInstantiate($this->class, $e);
     } catch (TypeError $e) {
-      throw new CannotInstantiate(new Type($this->class), $e);
+      throw new CannotInstantiate($this->class, $e);
     } catch (ReflectionException $e) {
-      throw new CannotInstantiate(new Type($this->class), $e);
+      throw new CannotInstantiate($this->class, $e);
     } catch (Throwable $e) {
 
       // This really should be an ArgumentCountError...
       if (0 === strpos($e->getMessage(), 'Unknown named parameter $')) {
-        throw new CannotInstantiate(new Type($this->class), $e);
+        throw new CannotInstantiate($this->class, $e);
       }
 
       throw new InvocationFailed($this, $e);

--- a/src/main/php/lang/reflection/Constructor.class.php
+++ b/src/main/php/lang/reflection/Constructor.class.php
@@ -52,16 +52,16 @@ class Constructor extends Routine implements Instantiation {
 
       return $this->class->newInstanceArgs($pass);
     } catch (ArgumentCountError $e) {
-      throw new CannotInstantiate($this->class->name, $e);
+      throw new CannotInstantiate(new Type($this->class), $e);
     } catch (TypeError $e) {
-      throw new CannotInstantiate($this->class->name, $e);
+      throw new CannotInstantiate(new Type($this->class), $e);
     } catch (ReflectionException $e) {
-      throw new CannotInstantiate($this->class->name, $e);
+      throw new CannotInstantiate(new Type($this->class), $e);
     } catch (Throwable $e) {
 
       // This really should be an ArgumentCountError...
       if (0 === strpos($e->getMessage(), 'Unknown named parameter $')) {
-        throw new CannotInstantiate($this->class->name, $e);
+        throw new CannotInstantiate(new Type($this->class), $e);
       }
 
       throw new InvocationFailed($this, $e);

--- a/src/main/php/lang/reflection/Initializer.class.php
+++ b/src/main/php/lang/reflection/Initializer.class.php
@@ -60,16 +60,16 @@ class Initializer extends Routine implements Instantiation {
       $this->function->__invoke($instance, $pass, $context);
       return $instance;
     } catch (ArgumentCountError $e) {
-      throw new CannotInstantiate($this->class->name, $e);
+      throw new CannotInstantiate(new Type($this->class), $e);
     } catch (TypeError $e) {
-      throw new CannotInstantiate($this->class->name, $e);
+      throw new CannotInstantiate(new Type($this->class), $e);
     } catch (ReflectionException $e) {
-      throw new CannotInstantiate($this->class->name, $e);
+      throw new CannotInstantiate(new Type($this->class), $e);
     } catch (Throwable $e) {
 
       // This really should be an ArgumentCountError...
       if (0 === strpos($e->getMessage(), 'Unknown named parameter $')) {
-        throw new CannotInstantiate($this->class->name, $e);
+        throw new CannotInstantiate(new Type($this->class), $e);
       }
 
       throw new InvocationFailed($this, $e);

--- a/src/main/php/lang/reflection/Initializer.class.php
+++ b/src/main/php/lang/reflection/Initializer.class.php
@@ -60,16 +60,16 @@ class Initializer extends Routine implements Instantiation {
       $this->function->__invoke($instance, $pass, $context);
       return $instance;
     } catch (ArgumentCountError $e) {
-      throw new CannotInstantiate(new Type($this->class), $e);
+      throw new CannotInstantiate($this->class, $e);
     } catch (TypeError $e) {
-      throw new CannotInstantiate(new Type($this->class), $e);
+      throw new CannotInstantiate($this->class, $e);
     } catch (ReflectionException $e) {
-      throw new CannotInstantiate(new Type($this->class), $e);
+      throw new CannotInstantiate($this->class, $e);
     } catch (Throwable $e) {
 
       // This really should be an ArgumentCountError...
       if (0 === strpos($e->getMessage(), 'Unknown named parameter $')) {
-        throw new CannotInstantiate(new Type($this->class), $e);
+        throw new CannotInstantiate($this->class, $e);
       }
 
       throw new InvocationFailed($this, $e);

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -218,18 +218,18 @@ class Type implements Value {
         return $this->reflect->newInstance();
       }
     } catch (ArgumentCountError $e) {
-      throw new CannotInstantiate($this->reflect->name, $e);
+      throw new CannotInstantiate($this, $e);
     } catch (TypeError $e) {
-      throw new CannotInstantiate($this->reflect->name, $e);
+      throw new CannotInstantiate($this, $e);
     } catch (ReflectionException $e) {
-      throw new CannotInstantiate($this->reflect->name, $e);
+      throw new CannotInstantiate($this, $e);
     } catch (Throwable $e) {
       if (0 === strpos($e->getMessage(), 'Unknown named parameter $')) {
-        throw new CannotInstantiate($this->reflect->name, $e);
+        throw new CannotInstantiate($this, $e);
       } else if ($this->reflect->isInstantiable() && $constructor) {
         throw new InvocationFailed($this->constructor(), $e);
       } else {
-        throw new CannotInstantiate($this->reflect->name);
+        throw new CannotInstantiate($this);
       }
     }
   }


### PR DESCRIPTION
Instead of having to rely on `getMessage()` containing the literal type name, add a dedicated accessor returning a `lang.reflection.Type` instance.