### PR TITLE
Migrate to new testing library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "php" : ">=7.4.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^11.0 | ^10.0"
+    "xp-framework/test": "^1.0"
   },
   "bin": ["bin/xp.xp-framework.reflection.reflect"],
   "autoload" : {

--- a/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AcceptsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\reflection\unittest;
 
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 use util\Date;
 
 class AcceptsTest {
@@ -194,7 +194,7 @@ class AcceptsTest {
     }
   }
 
-  #[Test, Values('fixtures')]
+  #[Test, Values(from: 'fixtures')]
   public function accept($t, $values, $size, $expected) {
     Assert::equals($expected, $t->method('fixture')->parameters()->accept($values, $size));
   }

--- a/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\reflection\unittest;
 
-use lang\reflection\{Annotation, InvocationFailed, CannotInstantiate};
-use lang\{XPClass, Reflection, IllegalStateException};
-use unittest\{Assert, Expect, Test, Values};
+use lang\reflection\{Annotation, CannotInstantiate, InvocationFailed};
+use lang\{IllegalStateException, Reflection, XPClass};
+use test\{Assert, Expect, Test, Values};
 
 class AnnotationTest {
   use TypeDefinition;
@@ -90,31 +90,31 @@ class AnnotationTest {
     yield [Reflection::type(Declared::class)];
   }
 
-  #[Test, Values('scalars')]
+  #[Test, Values(from: 'scalars')]
   public function with_scalar($annotation, $arguments) {
     $t= $this->declare('{}', $annotation);
     $this->assertAnnotations([Annotated::class => $arguments], $t->annotations());
   }
 
-  #[Test, Values('arrays')]
+  #[Test, Values(from: 'arrays')]
   public function with_array($annotation, $arguments) {
     $t= $this->declare('{}', $annotation);
     $this->assertAnnotations([Annotated::class => $arguments], $t->annotations());
   }
 
-  #[Test, Values('expressions')]
+  #[Test, Values(from: 'expressions')]
   public function with_expression($annotation, $arguments) {
     $t= $this->declare('{}', $annotation);
     $this->assertAnnotations([Annotated::class => $arguments], $t->annotations());
   }
 
-  #[Test, Values('arguments')]
+  #[Test, Values(from: 'arguments')]
   public function with($annotation, $arguments) {
     $t= $this->declare('{}', $annotation);
     $this->assertAnnotations([Annotated::class => $arguments], $t->annotations());
   }
 
-  #[Test, Values('evaluation')]
+  #[Test, Values(from: 'evaluation')]
   public function with_eval($annotation, $arguments) {
     $t= $this->declare('{ private static $member= "Test"; }', $annotation);
     $this->assertAnnotations([Annotated::class => $arguments], $t->annotations());
@@ -359,7 +359,7 @@ class AnnotationTest {
     $this->assertAnnotations([Error::class => [Fixture::class]], $t->annotations()->all(Error::class));
   }
 
-  #[Test, Values('types')]
+  #[Test, Values(from: 'types')]
   public function all_of($type) {
     $t= $this->declare('{}', '#[Annotated, Parameterized(1, 2), Error(Fixture::class)]');
     $this->assertAnnotations(

--- a/src/test/php/lang/reflection/unittest/ConstantsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ConstantsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\reflection\unittest;
 
-use unittest\actions\RuntimeVersion;
-use unittest\{Action, Assert, Test};
+use test\verify\Runtime;
+use test\{Action, Assert, Test};
 
 class ConstantsTest {
   use TypeDefinition;
@@ -27,7 +27,7 @@ class ConstantsTest {
     Assert::null($this->declare('{ const FIXTURE = "test"; }')->constant('FIXTURE')->comment());
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.1")')]
+  #[Test, Runtime(php: '>=7.1')]
   public function with_comment() {
     Assert::equals('Test', $this->declare('{ /** Test */ const FIXTURE = "test"; }')->constant('FIXTURE')->comment());
   }
@@ -53,19 +53,19 @@ class ConstantsTest {
     Assert::equals($t->constant('FIXTURE'), $t->constants()->named('FIXTURE'));
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.1")')]
+  #[Test, Runtime(php: '>=7.1')]
   public function private_constant() {
     $const= $this->declare('{ private const FIXTURE = "test"; }')->constant('FIXTURE');
     Assert::equals([MODIFIER_PRIVATE, 'test'], [$const->modifiers(), $const->value()]);
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.1")')]
+  #[Test, Runtime(php: '>=7.1')]
   public function protected_constant() {
     $const= $this->declare('{ protected const FIXTURE = "test"; }')->constant('FIXTURE');
     Assert::equals([MODIFIER_PROTECTED, 'test'], [$const->modifiers(), $const->value()]);
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.1")')]
+  #[Test, Runtime(php: '>=7.1')]
   public function public_constant() {
     $const= $this->declare('{ public const FIXTURE = "test"; }')->constant('FIXTURE');
     Assert::equals([MODIFIER_PUBLIC, 'test'], [$const->modifiers(), $const->value()]);

--- a/src/test/php/lang/reflection/unittest/ConstructorTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ConstructorTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\reflection\unittest;
 
 use lang\reflection\Constructor;
-use unittest\actions\RuntimeVersion;
-use unittest\{Action, Assert, Test};
+use test\verify\Runtime;
+use test\{Action, Assert, Test};
 
 class ConstructorTest {
   use TypeDefinition;

--- a/src/test/php/lang/reflection/unittest/EvaluateTest.class.php
+++ b/src/test/php/lang/reflection/unittest/EvaluateTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\reflection\unittest;
 
 use lang\{IllegalArgumentException, Reflection, Type};
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 
 class EvaluateTest {
   private static $EMPTY;
@@ -32,20 +32,20 @@ class EvaluateTest {
     yield ['function($arg) { if ($arg) { return "test"; } }', [true], 'test'];
   }
 
-  #[Test, Values('expressions')]
+  #[Test, Values(from: 'expressions')]
   public function evaluate($expression, $value) {
     Assert::equals($value, Reflection::of($this)->evaluate($expression));
   }
 
-  #[Test, Values('functions')]
+  #[Test, Values(from: 'functions')]
   public function run($expression, $args, $value) {
     $func= cast(Reflection::of($this)->evaluate($expression), 'callable');
     Assert::equals($value, $func(...$args));
   }
 
-  #[Test]
+  #[Test, Expect(class: IllegalArgumentException::class, message: 'Test')]
   public function throw_expression_supported_in_fn() {
     $func= Reflection::of($this)->evaluate('fn() => throw new \lang\IllegalArgumentException("Test")');
-    Assert::throws(IllegalArgumentException::class, $func);
+    $func();
   }
 }

--- a/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace lang\reflection\unittest;
 
 use lang\reflection\{CannotInstantiate, InvocationFailed};
-use lang\{Reflection, Runnable, CommandLine, Error, IllegalAccessException};
-use unittest\actions\RuntimeVersion;
-use unittest\{Assert, Action, Expect, Test, Values, AssertionFailedError};
+use lang\{CommandLine, Error, IllegalAccessException, Reflection, Runnable};
+use test\verify\Runtime;
+use test\{Action, Assert, AssertionFailedError, Expect, Test, Values};
 use util\Date;
 
 class InstantiationTest {
@@ -34,13 +34,13 @@ class InstantiationTest {
     Assert::instance($t->class(), $t->constructor()->newInstance());
   }
 
-  #[Test, Values('allInitializers')]
+  #[Test, Values(from: 'allInitializers')]
   public function with_empty_constructor($invocation) {
     $t= $this->declare('{ public function __construct() { }}');
     Assert::instance($t->class(), $invocation($t, []));
   }
 
-  #[Test, Values('allInitializers')]
+  #[Test, Values(from: 'allInitializers')]
   public function with_argument($invocation) {
     $t= $this->declare('{
       public $value= null;
@@ -49,7 +49,7 @@ class InstantiationTest {
     Assert::equals($this, $invocation($t, [$this])->value);
   }
 
-  #[Test, Values('allInitializers')]
+  #[Test, Values(from: 'allInitializers')]
   public function exceptions_are_wrapped($invocation) {
     $t= $this->declare('{ public function __construct() { throw new \lang\IllegalAccessException("Test"); } }');
     try {
@@ -60,7 +60,7 @@ class InstantiationTest {
     }
   }
 
-  #[Test, Values('allInitializers')]
+  #[Test, Values(from: 'allInitializers')]
   public function type_errors_are_wrapped($invocation) {
     $t= $this->declare('{
       public function __construct(\util\Date $date) { }
@@ -73,7 +73,7 @@ class InstantiationTest {
     }
   }
 
-  #[Test, Values('allInitializers')]
+  #[Test, Values(from: 'allInitializers')]
   public function missing_arguments_are_wrapped($invocation) {
     $t= $this->declare('{
       public function __construct(\util\Date $date) { }
@@ -107,7 +107,7 @@ class InstantiationTest {
     Assert::equals($this, $t->constructor()->newInstance([$this], $t)->value);
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
+  #[Test, Runtime(php: '>=8.0')]
   public function instantiate_with_constructor_promotion() {
     $t= $this->declare('{ public function __construct(public $value) { } }');
     Assert::equals($this, $t->constructor()->newInstance([$this])->value);
@@ -206,7 +206,7 @@ class InstantiationTest {
     $t->initializer('raise')->newInstance();
   }
 
-  #[Test, Values('memberInitializers')]
+  #[Test, Values(from: 'memberInitializers')]
   public function supports_named_arguments($invocation) {
     $t= $this->declare('{
       public $values;
@@ -215,7 +215,7 @@ class InstantiationTest {
     Assert::equals([1, 2], $invocation($t, ['b' => 2, 'a' => 1])->values);
   }
 
-  #[Test, Values('memberInitializers')]
+  #[Test, Values(from: 'memberInitializers')]
   public function supports_optional_named_arguments($invocation) {
     $t= $this->declare('{
       public $values;
@@ -224,7 +224,7 @@ class InstantiationTest {
     Assert::equals([1, 3], $invocation($t, ['b' => 3])->values);
   }
 
-  #[Test, Expect(CannotInstantiate::class), Values('memberInitializers')]
+  #[Test, Expect(CannotInstantiate::class), Values(from: 'memberInitializers')]
   public function excess_named_arguments_raise_error($invocation) {
     $t= $this->declare('{
       public $values;
@@ -233,7 +233,7 @@ class InstantiationTest {
     $invocation($t, ['b' => 2, 'a' => 1, 'extra' => 3]);
   }
 
-  #[Test, Expect(CannotInstantiate::class), Values('memberInitializers')]
+  #[Test, Expect(CannotInstantiate::class), Values(from: 'memberInitializers')]
   public function unknown_named_arguments_raise_error($invocation) {
     $t= $this->declare('{
       public $values;
@@ -242,7 +242,7 @@ class InstantiationTest {
     $invocation($t, ['c' => 3]);
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
+  #[Test, Runtime(php: '>=8.0')]
   public function newInstance_supports_named_arguments() {
     $t= $this->declare('{
       public $values;
@@ -251,7 +251,7 @@ class InstantiationTest {
     Assert::equals([1, 2], $t->newInstance(...['b' => 2, 'a' => 1])->values);
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
+  #[Test, Runtime(php: '>=8.0')]
   public function newInstance_supports_optional_named_arguments() {
     $t= $this->declare('{
       public $values;
@@ -260,7 +260,7 @@ class InstantiationTest {
     Assert::equals([1, 3], $t->newInstance(...['b' => 3])->values);
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")'), Expect(CannotInstantiate::class)]
+  #[Test, Runtime(php: '>=8.0'), Expect(CannotInstantiate::class)]
   public function excess_named_arguments_raise_error_for_newInstance() {
     $t= $this->declare('{
       public $values;
@@ -269,7 +269,7 @@ class InstantiationTest {
     $t->newInstance(...['b' => 2, 'a' => 1, 'extra' => 3]);
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")'), Expect(CannotInstantiate::class)]
+  #[Test, Runtime(php: '>=8.0'), Expect(CannotInstantiate::class)]
   public function unknown_named_arguments_raise_error_for_newInstance() {
     $t= $this->declare('{
       public $values;

--- a/src/test/php/lang/reflection/unittest/InvocationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/InvocationTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\reflection\unittest;
 
 use lang\reflection\{CannotInvoke, InvocationFailed};
-use lang\{Reflection, IllegalAccessException, Runnable, CommandLine};
-use unittest\{Assert, AssertionFailedError, Before, Values, Expect, Test};
+use lang\{CommandLine, IllegalAccessException, Reflection, Runnable};
+use test\{Assert, AssertionFailedError, Before, Expect, Test, Values};
 
 class InvocationTest {
   use TypeDefinition;

--- a/src/test/php/lang/reflection/unittest/MetaInformationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/MetaInformationTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\reflection\unittest;
 
 use lang\meta\MetaInformation;
-use unittest\{Assert, Before, After, Test};
+use test\{After, Assert, Before, Test, Values};
 
 class MetaInformationTest {
   private $reflect;

--- a/src/test/php/lang/reflection/unittest/MethodsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/MethodsTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\reflection\unittest;
 
-use lang\{Type, ArrayType, MapType, FunctionType, TypeUnion, TypeIntersection, Primitive, XPClass, IllegalStateException, IllegalArgumentException};
-use unittest\actions\RuntimeVersion;
-use unittest\{Assert, Expect, Test, Action, Values};
+use lang\{ArrayType, FunctionType, IllegalArgumentException, IllegalStateException, MapType, Primitive, Type, TypeIntersection, TypeUnion, XPClass};
+use test\verify\Runtime;
+use test\{Action, Assert, Expect, Test, Values};
 
 class MethodsTest {
   use TypeDefinition;
@@ -80,37 +80,37 @@ class MethodsTest {
     );
   }
 
-  #[Test, Values('returnTypes')]
+  #[Test, Values(from: 'returnTypes')]
   public function returns($decl, $present, $expected) {
     $returns= $this->declare('{ '.sprintf($decl, 'function fixture').' { } }')->method('fixture')->returns();
     Assert::equals([$present, $expected], [$returns->present(), $returns->type()]);
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.1")')]
+  #[Test, Runtime(php: '>=7.1')]
   public function returns_void() {
     $returns= $this->declare('{ function fixture(): void { } }')->method('fixture')->returns();
     Assert::equals(Type::$VOID, $returns->type());
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
+  #[Test, Runtime(php: '>=8.0')]
   public function returns_type_union() {
     $returns= $this->declare('{ function fixture(): string|int { } }')->method('fixture')->returns();
     Assert::equals(new TypeUnion([Primitive::$STRING, Primitive::$INT]), $returns->type());
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.1")')]
+  #[Test, Runtime(php: '>=8.1')]
   public function returns_never() {
     $returns= $this->declare('{ function fixture(): never { exit(); } }')->method('fixture')->returns();
     Assert::equals(Type::$NEVER, $returns->type());
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.1")')]
+  #[Test, Runtime(php: '>=8.1')]
   public function returns_type_intersection() {
     $returns= $this->declare('{ function fixture(): \Countable&\Traversable { } }')->method('fixture')->returns();
     Assert::equals(new TypeIntersection([new XPClass('Countable'), new XPClass('Traversable')]), $returns->type());
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.2")'), Values(['true', 'false'])]
+  #[Test, Runtime(php: '>=8.2'), Values(['true', 'false'])]
   public function returns_boolean_type($name) {
     $returns= $this->declare('{ function fixture(): '.$name.' { } }')->method('fixture')->returns();
     Assert::equals(Primitive::$BOOL, $returns->type());
@@ -122,7 +122,7 @@ class MethodsTest {
     Assert::equals($type->class(), $type->method('fixture')->returns()->type());
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.1")')]
+  #[Test, Runtime(php: '>=7.1')]
   public function return_never_more_specific_than_void() {
     $t= $this->declare('{ /** @return never */ function fixture(): void { exit(); } }');
     Assert::equals(Type::$NEVER, $t->method('fixture')->returns()->type());
@@ -225,7 +225,7 @@ class MethodsTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
+  #[Test, Runtime(php: '>=8.0')]
   public function string_representation_with_union_typed_parameter() {
     $t= $this->declare('{ public function fixture(string|int $s): string { } }');
     Assert::equals(
@@ -234,7 +234,7 @@ class MethodsTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
+  #[Test, Runtime(php: '>=8.0')]
   public function string_representation_with_nullable_union_typed_parameter() {
     $t= $this->declare('{ public function fixture(string|int|null $s): string { } }');
     Assert::equals(
@@ -243,7 +243,7 @@ class MethodsTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.1")')]
+  #[Test, Runtime(php: '>=8.1')]
   public function string_representation_with_intersection_typed_parameter() {
     $t= $this->declare('{ public function fixture(\Countable&\Traversable $s): string { } }');
     Assert::equals(
@@ -282,7 +282,7 @@ class MethodsTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
+  #[Test, Runtime(php: '>=8.0')]
   public function string_representation_with_union_typed_return() {
     $t= $this->declare('{ public function fixture(): string|int { } }');
     Assert::equals(
@@ -291,7 +291,7 @@ class MethodsTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.1")')]
+  #[Test, Runtime(php: '>=8.1')]
   public function string_representation_with_intersection_typed_return() {
     $t= $this->declare('{ public function fixture(): \Countable&\Traversable { } }');
     Assert::equals(

--- a/src/test/php/lang/reflection/unittest/ModifiersTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ModifiersTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\reflection\unittest;
 
 use lang\reflection\Modifiers;
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class ModifiersTest {
 
@@ -28,17 +28,17 @@ class ModifiersTest {
     new Modifiers(MODIFIER_PUBLIC);
   }
 
-  #[Test, Values('cases')]
+  #[Test, Values(from: 'cases')]
   public function names_from_bits($bits, $names) {
     Assert::equals($names, (new Modifiers($bits, false))->names());
   }
 
-  #[Test, Values('cases')]
+  #[Test, Values(from: 'cases')]
   public function bits_from_names($bits, $names) {
     Assert::equals($bits, (new Modifiers($names, false))->bits());
   }
 
-  #[Test, Values('cases')]
+  #[Test, Values(from: 'cases')]
   public function bits_from_name_array($bits, $names) {
     Assert::equals($bits, (new Modifiers(explode(' ', $names), false))->bits());
   }

--- a/src/test/php/lang/reflection/unittest/PackageTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PackageTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\IllegalArgumentException;
 use lang\reflection\Package;
-use unittest\{Assert, Test};
+use test\{Assert, Expect, Test, Values};
 
 class PackageTest {
 
@@ -52,7 +52,7 @@ class PackageTest {
     Assert::equals(self::class, (new Package(__NAMESPACE__))->type(self::class)->literal());
   }
 
-  #[Test, Expect(class: IllegalArgumentException::class, withMessage: 'Given type util.Date is not in package lang')]
+  #[Test, Expect(class: IllegalArgumentException::class, message: 'Given type util.Date is not in package lang')]
   public function type_with_namespace() {
     (new Package('lang'))->type('util.Date');
   }

--- a/src/test/php/lang/reflection/unittest/ParametersTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ParametersTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\reflection\unittest;
 
-use lang\{Type, ArrayType, FunctionType, TypeUnion, Primitive, IllegalStateException, IllegalArgumentException};
-use unittest\actions\RuntimeVersion;
-use unittest\{Assert, Expect, Test, Action, Values};
+use lang\{ArrayType, FunctionType, IllegalArgumentException, IllegalStateException, Primitive, Type, TypeUnion};
+use test\verify\Runtime;
+use test\{Action, Assert, Expect, Test, Values};
 
 class ParametersTest {
   use TypeDefinition;
@@ -29,7 +29,7 @@ class ParametersTest {
     Assert::null($this->declare('{ function fixture() { } }')->method('fixture')->parameter($lookup));
   }
 
-  #[Test, Values('types')]
+  #[Test, Values(from: 'types')]
   public function parameters($decl, $expected) {
     $method= $this->declare('{ '.sprintf($decl, 'function fixture').' { } }')->method('fixture');
     $actual= [];
@@ -140,7 +140,7 @@ class ParametersTest {
     Assert::equals($type->class(), $type->method('fixture')->parameter(0)->constraint()->type());
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
+  #[Test, Runtime(php: '>=8.0')]
   public function type_union_parameter_constraint() {
     $param= $this->declare('{ function fixture(string|int $arg) { } }')->method('fixture')->parameter(0);
     Assert::equals(new TypeUnion([Primitive::$STRING, Primitive::$INT]), $param->constraint()->type());

--- a/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace lang\reflection\unittest;
 
-use lang\reflection\{Modifiers, CannotAccess, AccessingFailed, Constraint};
-use lang\{Type, Primitive, TypeUnion, TypeIntersection, XPClass};
-use unittest\actions\RuntimeVersion;
-use unittest\{Assert, Action, Expect, Test, AssertionFailedError};
+use lang\reflection\{AccessingFailed, CannotAccess, Constraint, Modifiers};
+use lang\{Primitive, Type, TypeIntersection, TypeUnion, XPClass};
+use test\verify\Runtime;
+use test\{Action, Assert, AssertionFailedError, Expect, Test, Values};
 
 class PropertiesTest {
   use TypeDefinition;
@@ -103,7 +103,7 @@ class PropertiesTest {
     $type->property('fixture')->set(null, 'Modified', typeof($this));
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.4")'), Expect(AccessingFailed::class)]
+  #[Test, Runtime(php: '>=7.4'), Expect(AccessingFailed::class)]
   public function type_mismatch() {
     $type= $this->declare('{ private static array $fixture; }');
     $type->property('fixture')->set(null, 1, $type);
@@ -145,7 +145,7 @@ class PropertiesTest {
     Assert::equals(new Constraint(Primitive::$STRING, false), $type->property('fixture')->constraint());
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.4")')]
+  #[Test, Runtime(php: '>=7.4')]
   public function type_from_declaration() {
     $type= $this->declare('{ public string $fixture; }');
     Assert::equals(
@@ -154,7 +154,7 @@ class PropertiesTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.4")')]
+  #[Test, Runtime(php: '>=7.4')]
   public function type_from_array_declaration() {
     $type= $this->declare('{ public array $fixture; }');
     Assert::equals(
@@ -163,7 +163,7 @@ class PropertiesTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.4")')]
+  #[Test, Runtime(php: '>=7.4')]
   public function type_from_self_declaration() {
     $type= $this->declare('{ public self $fixture; }');
     Assert::equals(
@@ -172,7 +172,7 @@ class PropertiesTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
+  #[Test, Runtime(php: '>=8.0')]
   public function type_from_union_declaration() {
     $type= $this->declare('{ public string|int $fixture; }');
     Assert::equals(
@@ -181,7 +181,7 @@ class PropertiesTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.1")')]
+  #[Test, Runtime(php: '>=8.1')]
   public function type_from_intersection_declaration() {
     $type= $this->declare('{ public \Countable&\Traversable $fixture; }');
     Assert::equals(
@@ -190,7 +190,7 @@ class PropertiesTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.2")'), Values(['true', 'false'])]
+  #[Test, Runtime(php: '>=8.2'), Values(['true', 'false'])]
   public function type_from_boolean_types($name) {
     $type= $this->declare('{ public '.$name.' $fixture; }');
     Assert::equals(
@@ -217,7 +217,7 @@ class PropertiesTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.4")')]
+  #[Test, Runtime(php: '>=7.4')]
   public function string_representation_with_type_declaration() {
     $t= $this->declare('{ public string $fixture; }');
     Assert::equals(
@@ -226,7 +226,7 @@ class PropertiesTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
+  #[Test, Runtime(php: '>=8.0')]
   public function string_representation_with_union_type_declaration() {
     $t= $this->declare('{ public string|int $fixture; }');
     Assert::equals(
@@ -235,7 +235,7 @@ class PropertiesTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.4")')]
+  #[Test, Runtime(php: '>=7.4')]
   public function accessing_failed_target() {
     $t= $this->declare('{ public static array $fixture; }');
     try {

--- a/src/test/php/lang/reflection/unittest/ReflectionTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ReflectionTest.class.php
@@ -3,8 +3,8 @@
 use ReflectionClass, ReflectionObject;
 use lang\meta\{FromAttributes, FromSyntaxTree};
 use lang\reflection\Package;
-use lang\{Reflection, Type, ClassNotFoundException};
-use unittest\{Assert, Test, Values, Expect};
+use lang\{ClassNotFoundException, Reflection, Type};
+use test\{Assert, Expect, Test, Values};
 
 class ReflectionTest {
 
@@ -19,12 +19,12 @@ class ReflectionTest {
     yield [new ReflectionObject($this), 'reflection object'];
   }
 
-  #[Test, Values('arguments')]
+  #[Test, Values(from: 'arguments')]
   public function of($argument) {
     Assert::equals(nameof($this), Reflection::of($argument)->name());
   }
 
-  #[Test, Values('arguments')]
+  #[Test, Values(from: 'arguments')]
   public function type($argument) {
     Assert::equals(nameof($this), Reflection::type($argument)->name());
   }

--- a/src/test/php/lang/reflection/unittest/TypeTest.class.php
+++ b/src/test/php/lang/reflection/unittest/TypeTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace lang\reflection\unittest;
 
-use lang\reflection\{Kind, Modifiers, Annotations, Constants, Properties, Methods, Package};
-use lang\{ElementNotFoundException, Reflection, Enum, Runnable, XPClass, ClassLoader};
-use unittest\actions\{VerifyThat, RuntimeVersion};
-use unittest\{Action, Assert, Before, Test};
+use lang\reflection\{Annotations, Constants, Kind, Methods, Modifiers, Package, Properties};
+use lang\{ClassLoader, ElementNotFoundException, Enum, Reflection, Runnable, XPClass};
+use test\verify\{Condition, Runtime};
+use test\{Action, Assert, Before, Test};
 
 class TypeTest {
   private $fixture;
@@ -78,7 +78,7 @@ class TypeTest {
     Assert::equals(new Modifiers('public native'), $t->modifiers());
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.2")')]
+  #[Test, Runtime(php: '>=8.2')]
   public function readonly_modifiers() {
     $t= $this->declare('M_R', ['modifiers' => 'readonly']);
     Assert::equals(new Modifiers('public readonly'), $t->modifiers());
@@ -108,13 +108,13 @@ class TypeTest {
     Assert::equals(Kind::$ENUM, $t->kind());
   }
 
-  #[Test, Action(eval: 'new VerifyThat(fn() => !self::$ENUMS)')]
+  #[Test, Condition(assert: '!self::$ENUMS')]
   public function enum_kind_for_enum_lookalikes() {
     $t= $this->declare('K_LE', ['kind' => 'class', 'implements' => [\UnitEnum::class]], '{ public static $M; }');
     Assert::equals(Kind::$ENUM, $t->kind());
   }
 
-  #[Test, Action(eval: 'new VerifyThat(fn() => self::$ENUMS)')]
+  #[Test, Condition(assert: 'self::$ENUMS')]
   public function enum_kind_for_native_enums() {
     $t= $this->declare('K_NE', ['kind' => 'enum'], '{ case M; }');
     Assert::equals(Kind::$ENUM, $t->kind());
@@ -201,13 +201,13 @@ class TypeTest {
     Assert::equals('annotated', $this->fixture->annotation(Annotated::class)->name());
   }
 
-  #[Test, Action(eval: 'new VerifyThat(fn() => self::$ENUMS)')]
+  #[Test, Condition(assert: 'fn() => self::$ENUMS')]
   public function enum_annotation() {
    $t= $this->declare('A_E', ['kind' => 'enum'], '{ case M; }');
     Assert::equals('annotated', $t->annotation(Annotated::class)->name());
   }
 
-  #[Test, Action(eval: 'new VerifyThat(fn() => self::$ENUMS)')]
+  #[Test, Condition(assert: 'fn() => self::$ENUMS')]
   public function enum_case_annotation() {
    $t= $this->declare('A_C', ['kind' => 'enum'], '{ #[Annotated] case M; }');
     Assert::equals('annotated', $t->constant('M')->annotation(Annotated::class)->name());

--- a/src/test/php/lang/reflection/unittest/TypeTest.class.php
+++ b/src/test/php/lang/reflection/unittest/TypeTest.class.php
@@ -201,13 +201,13 @@ class TypeTest {
     Assert::equals('annotated', $this->fixture->annotation(Annotated::class)->name());
   }
 
-  #[Test, Condition(assert: 'fn() => self::$ENUMS')]
+  #[Test, Condition(assert: 'self::$ENUMS')]
   public function enum_annotation() {
    $t= $this->declare('A_E', ['kind' => 'enum'], '{ case M; }');
     Assert::equals('annotated', $t->annotation(Annotated::class)->name());
   }
 
-  #[Test, Condition(assert: 'fn() => self::$ENUMS')]
+  #[Test, Condition(assert: 'self::$ENUMS')]
   public function enum_case_annotation() {
    $t= $this->declare('A_C', ['kind' => 'enum'], '{ #[Annotated] case M; }');
     Assert::equals('annotated', $t->constant('M')->annotation(Annotated::class)->name());

--- a/src/test/php/lang/reflection/unittest/VirtualPropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/VirtualPropertiesTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\reflection\unittest;
 
 use lang\Reflection;
-use lang\reflection\{Modifiers, AccessingFailed};
-use unittest\{Assert, Values, Expect, Test};
+use lang\reflection\{AccessingFailed, Modifiers};
+use test\{Assert, Expect, Test, Values};
 
 class VirtualPropertiesTest {
   use TypeDefinition;
@@ -23,12 +23,12 @@ class VirtualPropertiesTest {
     }
   }
 
-  #[Test, Values('fixtures')]
+  #[Test, Values(from: 'fixtures')]
   public function readonly_modifier_shown_in_string_representation($type) {
     Assert::equals('public readonly string $fixture', $type->property('fixture')->toString());
   }
 
-  #[Test, Values('fixtures')]
+  #[Test, Values(from: 'fixtures')]
   public function virtual_property_included_in_list($type) {
     Assert::equals(
       ['fixture' => 'public readonly'],
@@ -36,12 +36,12 @@ class VirtualPropertiesTest {
     );
   }
 
-  #[Test, Values('fixtures')]
+  #[Test, Values(from: 'fixtures')]
   public function named_virtual($type) {
     Assert::equals($type->property('fixture'), $type->properties()->named('fixture'));
   }
 
-  #[Test, Values('fixtures')]
+  #[Test, Values(from: 'fixtures')]
   public function initializing_readonly_allowed($type) {
     $property= $type->property('fixture');
     $instance= $type->newInstance();
@@ -49,7 +49,7 @@ class VirtualPropertiesTest {
     $property->set($instance, 'Test');
   }
 
-  #[Test, Values('fixtures')]
+  #[Test, Values(from: 'fixtures')]
   public function reading_readonly($type) {
     $property= $type->property('fixture');
     $instance= $type->newInstance();
@@ -58,7 +58,7 @@ class VirtualPropertiesTest {
     Assert::equals('Test', $property->get($instance));
   }
 
-  #[Test, Expect(AccessingFailed::class), Values('fixtures')]
+  #[Test, Expect(AccessingFailed::class), Values(from: 'fixtures')]
   public function overwriting_readonly_not_allowed($type) {
     $property= $type->property('fixture');
     $instance= $type->newInstance();


### PR DESCRIPTION
See https://github.com/xp-framework/rfc/issues/344 and https://github.com/xp-framework/test. Mostly migrated automatically, needed fixes for missing imports, adjustments for VerifyThat with `fn` and correcting global imports (`ReflectionClass`) ending up as `use \eflectionClass`.

Includes a fix for function expressions used inside annotations for PHP 7.x
