### PR TITLE
Add support for class constants types

### DIFF
--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -35,7 +35,7 @@ class MetaInformation {
   /**
    * Parses tags from API documentation
    *
-   * @param  \ReflectionClass|\ReflectionConstant|\ReflectionProperty|\ReflectionMethod $reflect
+   * @param  \ReflectionClass|\ReflectionClassConstant|\ReflectionProperty|\ReflectionMethod $reflect
    * @return [:var]
    */
   private function tags($reflect) {

--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -104,6 +104,23 @@ class MetaInformation {
   }
 
   /**
+   * Returns type for a given constant
+   *
+   * @see    https://stackoverflow.com/questions/3892063/phpdoc-class-constants-documentation
+   * @param  \ReflectionClassConstant $reflect
+   * @return ?string
+   */
+  public function constantType($reflect) {
+    $c= strtr($reflect->getDeclaringClass()->name, '\\', '.');
+    if ($meta= \xp::$meta[$c][2][$reflect->name] ?? null) {
+      return $meta[DETAIL_RETURNS];
+    } else {
+      $tags= $this->tags($reflect);
+      return $tags['var'][0] ?? $tags['type'][0] ?? null;
+    }
+  }
+
+  /**
    * Returns comment for a given constant
    *
    * @param  \ReflectionClassConstant $reflect

--- a/src/main/php/lang/reflection/Constant.class.php
+++ b/src/main/php/lang/reflection/Constant.class.php
@@ -32,10 +32,8 @@ class Constant extends Member {
       return Reflection::meta()->constantType($this->reflect);
     };
 
-    // FIXME use `PHP_VERSION_ID >= 80300 ? $this->reflect->getType() : null`
-    // when php/php-src#10444 is merged.
     $t= Type::resolve(
-      method_exists($this->reflect, 'getType') ? $this->reflect->getType() : null,
+      PHP_VERSION_ID >= 80300 ? $this->reflect->getType() : null,
       Member::resolve($this->reflect),
       $api
     );
@@ -52,7 +50,7 @@ class Constant extends Member {
   public function toString() {
 
     // Compile constant type
-    $t= method_exists($this->reflect, 'getType') ? $this->reflect->getType() : null;
+    $t= PHP_VERSION_ID >= 80300 ? $this->reflect->getType() : null;
     if (null === $t) {
       $type= Reflection::meta()->constantType($this->reflect) ?? 'var';
     } else if ($t instanceof ReflectionUnionType) {

--- a/src/main/php/lang/reflection/Constant.class.php
+++ b/src/main/php/lang/reflection/Constant.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\reflection;
 
-use lang\Reflection;
+use lang\{Type, Reflection};
 use util\Objects;
 
 /**
@@ -22,6 +22,26 @@ class Constant extends Member {
   /** Returns a compound name consisting of `[CLASS]::$[NAME]`  */
   public function compoundName(): string { return strtr($this->reflect->class, '\\', '.').'::'.$this->reflect->name; }
 
+  /** @return lang.reflection.Constraint */
+  public function constraint() {
+    $present= true;
+
+    // Only use meta information if necessary
+    $api= function($set) use(&$present) {
+      $present= $set;
+      return Reflection::meta()->constantType($this->reflect);
+    };
+
+    // FIXME use `PHP_VERSION_ID >= 80300 ? $this->reflect->getType() : null`
+    // when php/php-src#10444 is merged.
+    $t= Type::resolve(
+      method_exists($this->reflect, 'getType') ? $this->reflect->getType() : null,
+      Member::resolve($this->reflect),
+      $api
+    );
+    return new Constraint($t ?? Type::$VAR, $present);
+  }
+
   /** @return int */
   public function modifiers() { return $this->reflect->getModifiers(); }
 
@@ -30,8 +50,24 @@ class Constant extends Member {
 
   /** @return string */
   public function toString() {
-    return sprintf('%s const %s = %s',
+
+    // Compile constant type
+    $t= method_exists($this->reflect, 'getType') ? $this->reflect->getType() : null;
+    if (null === $t) {
+      $type= Reflection::meta()->constantType($this->reflect) ?? 'var';
+    } else if ($t instanceof ReflectionUnionType) {
+      $type= '';
+      foreach ($t->getTypes() as $component) {
+        $type.= '|'.$component->getName();
+      }
+      $type= substr($type, 1);
+    } else {
+      $type= $t->getName();
+    }
+
+    return sprintf('%s const %s %s = %s',
       Modifiers::namesOf($this->reflect->getModifiers()),
+      $type,
       $this->reflect->name,
       Objects::stringOf($this->reflect->getValue())
     );

--- a/src/main/php/module.xp
+++ b/src/main/php/module.xp
@@ -28,7 +28,21 @@ module xp-framework/reflect {
 
         public function getValue() { return $this->reflect->getConstant($this->name); }
 
-        public function getDocComment() { return false; }
+        public function getDocComment() {
+          $tokens= token_get_all(file_get_contents($this->reflect->getFileName()));
+          $const= false;
+          for ($i= 0, $s= sizeof($tokens); $i < $s; $i++) {
+            if (T_DOC_COMMENT === $tokens[$i][0]) {
+              $comment= $tokens[$i][1];
+            } else if (T_CONST === $tokens[$i][0]) {
+              $const= true;
+            } else if ($const && "=" === $tokens[$i][0]) {
+              $const= false;
+              if ($this->name === $tokens[$i - 2][1]) return $comment;
+            }
+          }
+          return false;
+        }
 
         public function getDeclaringClass() { 
           $reflect= $this->reflect;

--- a/src/main/php/module.xp
+++ b/src/main/php/module.xp
@@ -30,15 +30,16 @@ module xp-framework/reflect {
 
         public function getDocComment() {
           $tokens= token_get_all(file_get_contents($this->reflect->getFileName()));
-          $const= false;
+          $const= $comment= false;
           for ($i= 0, $s= sizeof($tokens); $i < $s; $i++) {
             if (T_DOC_COMMENT === $tokens[$i][0]) {
               $comment= $tokens[$i][1];
             } else if (T_CONST === $tokens[$i][0]) {
               $const= true;
             } else if ($const && "=" === $tokens[$i][0]) {
-              $const= false;
               if ($this->name === $tokens[$i - 2][1]) return $comment;
+              $const= false;
+              $comment= false;
             }
           }
           return false;

--- a/src/test/php/lang/reflection/unittest/ConstantsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ConstantsTest.class.php
@@ -98,7 +98,7 @@ class ConstantsTest {
     );
   }
 
-  #[Test, Runtime(php: '>=8.3')]
+  #[Test, Runtime(php: '>=8.3.0-dev')]
   public function with_constraint() {
     Assert::equals(
       new Constraint(Primitive::$STRING, true),

--- a/src/test/php/lang/reflection/unittest/ConstantsTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ConstantsTest.class.php
@@ -1,7 +1,9 @@
 <?php namespace lang\reflection\unittest;
 
+use lang\reflection\Constraint;
+use lang\{Primitive, Type};
 use test\verify\Runtime;
-use test\{Action, Assert, Test};
+use test\{Assert, Test, Values};
 
 class ConstantsTest {
   use TypeDefinition;
@@ -75,8 +77,32 @@ class ConstantsTest {
   public function string_representation() {
     $t= $this->declare('{ const FIXTURE = "test"; }');
     Assert::equals(
-      'public const FIXTURE = "test"',
+      'public const var FIXTURE = "test"',
       $t->constant('FIXTURE')->toString()
+    );
+  }
+
+  #[Test]
+  public function without_constraint() {
+    Assert::equals(
+      new Constraint(Type::$VAR, false),
+      $this->declare('{ const FIXTURE = "test"; }')->constant('FIXTURE')->constraint()
+    );
+  }
+
+  #[Test, Values(['/** @type string */', '/** @var string */'])]
+  public function with_constraint_in_apidoc($comment) {
+    Assert::equals(
+      new Constraint(Primitive::$STRING, false),
+      $this->declare('{ '.$comment.' const FIXTURE = "test"; }')->constant('FIXTURE')->constraint()
+    );
+  }
+
+  #[Test, Runtime(php: '>=8.3')]
+  public function with_constraint() {
+    Assert::equals(
+      new Constraint(Primitive::$STRING, true),
+      $this->declare('{ const string FIXTURE = "test"; }')->constant('FIXTURE')->constraint()
     );
   }
 }


### PR DESCRIPTION
See https://wiki.php.net/rfc/typed_class_constants, targeted for PHP 8.3:

```php
class Tests {
  const string PREFIX= "Test";
}

$c= Reflection::type(Tests::class)->constant('PREFIX')->constraint();
$c->present(); // true
$c->type();    // Primitive::$STRING
```

Also supports `@var` and `@type` apidocs, see https://stackoverflow.com/questions/3892063/phpdoc-class-constants-documentation