### PR TITLE
Add support for multiple evaluated annotation arguments

### DIFF
--- a/src/main/php/lang/meta/FromAttributes.class.php
+++ b/src/main/php/lang/meta/FromAttributes.class.php
@@ -13,7 +13,10 @@ class FromAttributes {
     $r= [];
     foreach ($reflect->getAttributes() as $attribute) {
       $args= $attribute->getArguments();
-      if ('eval' === key($args)) {
+      $key= key($args);
+      if ('yield' === $key) {
+        $r[$attribute->getName()]= $this->evaluate($context, $args['yield']);
+      } else if ('eval' === $key) {
         $r[$attribute->getName()]= [$this->evaluate($context, $args['eval'])];
       } else {
         $r[$attribute->getName()]= $args;

--- a/src/main/php/lang/meta/FromAttributes.class.php
+++ b/src/main/php/lang/meta/FromAttributes.class.php
@@ -14,8 +14,8 @@ class FromAttributes {
     foreach ($reflect->getAttributes() as $attribute) {
       $args= $attribute->getArguments();
       $key= key($args);
-      if ('yield' === $key) {
-        $r[$attribute->getName()]= $this->evaluate($context, $args['yield']);
+      if ('use' === $key) {
+        $r[$attribute->getName()]= $this->evaluate($context, $args['use']);
       } else if ('eval' === $key) {
         $r[$attribute->getName()]= [$this->evaluate($context, $args['eval'])];
       } else {
@@ -57,7 +57,7 @@ class FromAttributes {
    * @return [:string]
    */
   public function imports($reflect) {
-    static $break= [T_CLASS => true, T_INTERFACE => true, T_TRAIT => true];
+    static $break= [T_CLASS => true, T_INTERFACE => true, T_TRAIT => true, T_ENUM => true, T_ATTRIBUTE => true];
 
     $tokens= \PhpToken::tokenize(file_get_contents($reflect->getFileName()));
     $imports= [];

--- a/src/main/php/lang/meta/FromSyntaxTree.class.php
+++ b/src/main/php/lang/meta/FromSyntaxTree.class.php
@@ -159,8 +159,11 @@ class FromSyntaxTree {
 
     $r= [];
     foreach ($annotated->annotations as $type => $arguments) {
-      if ('eval' === key($arguments)) {
-        $parsed= self::parse($arguments['eval']->visit($tree).';', $tree->resolver());
+      if ($yield= $arguments['yield'] ?? null) {
+        $parsed= self::parse($yield->visit($tree).';', $tree->resolver());
+        $r[$type]= $parsed->tree()->children()[0]->visit($tree);
+      } else if ($eval= $arguments['eval'] ?? null) {
+        $parsed= self::parse($eval->visit($tree).';', $tree->resolver());
         $r[$type]= [$parsed->tree()->children()[0]->visit($tree)];
       } else {
         $p= &$r[$type];

--- a/src/main/php/lang/meta/FromSyntaxTree.class.php
+++ b/src/main/php/lang/meta/FromSyntaxTree.class.php
@@ -159,11 +159,12 @@ class FromSyntaxTree {
 
     $r= [];
     foreach ($annotated->annotations as $type => $arguments) {
-      if ($yield= $arguments['yield'] ?? null) {
-        $parsed= self::parse($yield->visit($tree).';', $tree->resolver());
+      $key= key($arguments);
+      if ('use' === $key) {
+        $parsed= self::parse($arguments['use']->visit($tree).';', $tree->resolver());
         $r[$type]= $parsed->tree()->children()[0]->visit($tree);
-      } else if ($eval= $arguments['eval'] ?? null) {
-        $parsed= self::parse($eval->visit($tree).';', $tree->resolver());
+      } else if ('eval' === $key) {
+        $parsed= self::parse($arguments['eval']->visit($tree).';', $tree->resolver());
         $r[$type]= [$parsed->tree()->children()[0]->visit($tree)];
       } else {
         $p= &$r[$type];

--- a/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
@@ -169,14 +169,14 @@ class AnnotationTest {
   }
 
   #[Test]
-  public function yield_arguments() {
-    $t= $this->declare('{}', '#[Annotated(yield: "[1, 2, 3]")]');
+  public function use_arguments() {
+    $t= $this->declare('{}', '#[Annotated(use: "[1, 2, 3]")]');
     $this->assertAnnotations([Annotated::class => [1, 2, 3]], $t->annotations());
   }
 
   #[Test]
-  public function yield_named_arguments() {
-    $t= $this->declare('{}', '#[Annotated(yield: "[\"power\" => 6100]")]');
+  public function use_named_arguments() {
+    $t= $this->declare('{}', '#[Annotated(use: "[\"power\" => 6100]")]');
     $this->assertAnnotations([Annotated::class => ['power' => 6100]], $t->annotations());
   }
 

--- a/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
@@ -169,6 +169,18 @@ class AnnotationTest {
   }
 
   #[Test]
+  public function yield_arguments() {
+    $t= $this->declare('{}', '#[Annotated(yield: "[1, 2, 3]")]');
+    $this->assertAnnotations([Annotated::class => [1, 2, 3]], $t->annotations());
+  }
+
+  #[Test]
+  public function yield_named_arguments() {
+    $t= $this->declare('{}', '#[Annotated(yield: "[\"power\" => 6100]")]');
+    $this->assertAnnotations([Annotated::class => ['power' => 6100]], $t->annotations());
+  }
+
+  #[Test]
   public function multiple() {
     $t= $this->declare('{}', '#[Annotated, Enumeration([])]');
     $this->assertAnnotations([Annotated::class => [], Enumeration::class => [[]]], $t->annotations());


### PR DESCRIPTION
## Feature

Currently, we can only supply one annotation argument via *eval*:

```php
#[Callback(eval: 'fn() => ...')]
class T { }

Reflection::type(T::class)->annotation(Callback::class)->argument(0); // Closure
```

This pull request add the possibility to supply multiple arguments using *use*:

```php
#[Callbacks(use: '[fn() => 1, fn() => 2]')]
class T { }

Reflection::type(T::class)->annotation(Callbacks::class)->arguments(); // [Closure#1, Closure#2]
```

It also supports named arguments:

```php
#[Callback(use: '["function" => fn() => ...]')]
class T { }

Reflection::type(T::class)->annotation(Callback::class)->argument('function'); // Closure
```

*In a nutshell: `use` is the `eval` we should have had from the beginning!*

## Choice of keyword

Unfortunately, there is no way without badly breaking existing code to transition from the single-value semantic of `eval` to the argment-list semantic we're introducing here, and keep the `eval` keyword at the same time. Here's a list of alternative choices I considered:

* [ ] ~~`eval` - because we **evaluate** a string; impossible~~
* [ ] `string` - because we evaluate a **string**
* [ ] `try` - because we **try** to evaluate the string
* [ ] `yield` - because we yield the argument list "into" the braces
* [x] `use` - because we use the argument list
* [ ] `include` - because the string is included as an expression
* [ ] `const` - because we have a constant string (a bit far fetched)
* [ ] `declare` - because the following string contains a declaration (also a bit far fetched)
* [ ] `lazy` - because the expression is not evaluated until the annotation is used
 
See also https://www.php.net/manual/en/reserved.keywords.php and https://scalaexplained.github.io/scala-explained/keywords.html#lazy