### PR TITLE
Add support for multiple arguments using arrays in `eval`

### DIFF
--- a/src/main/php/lang/meta/FromAttributes.class.php
+++ b/src/main/php/lang/meta/FromAttributes.class.php
@@ -13,10 +13,17 @@ class FromAttributes {
     $r= [];
     foreach ($reflect->getAttributes() as $attribute) {
       $args= $attribute->getArguments();
-      if ('eval' === key($args)) {
-        $r[$attribute->getName()]= $this->evaluate($context, $args['eval']);
+      $ptr= &$r[$attribute->getName()];
+
+      if (!isset($args['eval'])) {
+        $ptr= $args;
+      } else if (is_array($args['eval'])) {
+        $ptr= [];
+        foreach ($args['eval'] as $key => $value) {
+          $ptr[$key]= $this->evaluate($context, $value);
+        }
       } else {
-        $r[$attribute->getName()]= $args;
+        $ptr= [$this->evaluate($context, $args['eval'])];
       }
     }
     return $r;

--- a/src/main/php/lang/meta/FromAttributes.class.php
+++ b/src/main/php/lang/meta/FromAttributes.class.php
@@ -14,7 +14,7 @@ class FromAttributes {
     foreach ($reflect->getAttributes() as $attribute) {
       $args= $attribute->getArguments();
       if ('eval' === key($args)) {
-        $r[$attribute->getName()]= [$this->evaluate($context, $args['eval'])];
+        $r[$attribute->getName()]= $this->evaluate($context, $args['eval']);
       } else {
         $r[$attribute->getName()]= $args;
       }

--- a/src/main/php/lang/meta/FromSyntaxTree.class.php
+++ b/src/main/php/lang/meta/FromSyntaxTree.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\meta;
 
 use lang\IllegalArgumentException;
-use lang\ast\nodes\FunctionDeclaration;
+use lang\ast\nodes\{ArrayLiteral, FunctionDeclaration};
 use lang\ast\{Language, Token, Tokens, Visitor, Code};
 
 /**
@@ -136,8 +136,8 @@ class FromSyntaxTree {
     return self::$parse->parse(new Tokens($code.';', '(evaluated)'), $resolver);
   }
 
-  public function evaluate($reflect, $code) {
-    $tree= $this->tree($reflect);
+  public function evaluate($arg, $code) {
+    $tree= $arg instanceof SyntaxTree ? $arg : $this->tree($arg);
     $parsed= self::parse($code, $tree->resolver())->tree()->children();
     if (1 === sizeof($parsed)) {
       return $parsed[0]->visit($tree);
@@ -158,19 +158,22 @@ class FromSyntaxTree {
     if (null === $annotated->annotations) return [];
 
     $r= [];
-    foreach ($annotated->annotations as $type => $arguments) {
-      if ('eval' === key($arguments)) {
-        $r[$type]= self::parse($arguments['eval']->visit($tree).';', $tree->resolver())
-          ->tree()
-          ->children()[0]
-          ->visit($tree)
-        ;
-      } else {
-        $p= &$r[$type];
-        $p= [];
-        foreach ($arguments as $name => $argument) {
-          $p[$name]= $argument->visit($tree);
+    foreach ($annotated->annotations as $type => $args) {
+      $ptr= &$r[$type];
+
+      if (!isset($args['eval'])) {
+        $ptr= [];
+        foreach ($args as $name => $argument) {
+          $ptr[$name]= $argument->visit($tree);
         }
+      } else if ($args['eval'] instanceof ArrayLiteral) {
+        $ptr= [];
+        $i= 0;
+        foreach ($args['eval']->values as list($key, $value)) {
+          $ptr[$key ? $key->visit($tree) : $i++]= $this->evaluate($tree, $value->visit($tree).';');
+        }
+      } else {
+        $ptr= [$this->evaluate($tree, $args['eval']->visit($tree).';')];
       }
     }
     return $r;

--- a/src/main/php/lang/meta/FromSyntaxTree.class.php
+++ b/src/main/php/lang/meta/FromSyntaxTree.class.php
@@ -160,8 +160,11 @@ class FromSyntaxTree {
     $r= [];
     foreach ($annotated->annotations as $type => $arguments) {
       if ('eval' === key($arguments)) {
-        $parsed= self::parse($arguments['eval']->visit($tree).';', $tree->resolver());
-        $r[$type]= [$parsed->tree()->children()[0]->visit($tree)];
+        $r[$type]= self::parse($arguments['eval']->visit($tree).';', $tree->resolver())
+          ->tree()
+          ->children()[0]
+          ->visit($tree)
+        ;
       } else {
         $p= &$r[$type];
         $p= [];

--- a/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
@@ -76,11 +76,13 @@ class AnnotationTest {
 
   /** @return iterable */
   private function evaluation() {
-    yield ['#[Annotated(eval: "[\"Test\"]")]', ['Test']];
-    yield ['#[Annotated(eval: \'["Test"]\')]', ['Test']];
-    yield ['#[Annotated(eval: "[new Fixture()]")]', [new Fixture()]];
-    yield ['#[Annotated(eval: "[Fixture::\$DEFAULT]")]', [Fixture::$DEFAULT]];
-    yield ['#[Annotated(eval: "[self::\$member]")]', ['Test']];
+    yield ['#[Annotated(eval: "\"Test\"")]', ['Test']];
+    yield ['#[Annotated(eval: \'"Test"\')]', ['Test']];
+    yield ['#[Annotated(eval: "new Fixture()")]', [new Fixture()]];
+    yield ['#[Annotated(eval: "Fixture::\$DEFAULT")]', [Fixture::$DEFAULT]];
+    yield ['#[Annotated(eval: "self::\$member")]', ['Test']];
+    yield ['#[Annotated(eval: ["1", "2"])]', [1, 2]];
+    yield ['#[Annotated(eval: ["one" => "1", "two" => "2"])]', ['one' => 1, 'two' => 2]];
   }
 
   /** @return iterable */
@@ -134,7 +136,7 @@ class AnnotationTest {
 
   #[Test]
   public function with_function() {
-    $t= $this->declare('{}', '#[Annotated(eval: "[function() { return 6100; }]")]');
+    $t= $this->declare('{}', '#[Annotated(eval: "function() { return 6100; }")]');
     $f= $t->annotation(Annotated::class)->argument(0);
 
     Assert::instance('callable', $f);
@@ -143,7 +145,7 @@ class AnnotationTest {
 
   #[Test, Values([['fn() => 6100', 6100], ['fn() => array(1, array(2))', [1, [2]]], ['fn() => [array(1), array(2)]', [[1], [2]]]])]
   public function with_lambda($code, $expected) {
-    $t= $this->declare('{}', '#[Annotated(eval: "['.$code.']")]');
+    $t= $this->declare('{}', '#[Annotated(eval: "'.$code.'")]');
     $f= $t->annotation(Annotated::class)->argument(0);
 
     Assert::instance('callable', $f);
@@ -152,7 +154,7 @@ class AnnotationTest {
 
   #[Test]
   public function with_nested_lambda() {
-    $t= $this->declare('{}', '#[Annotated(eval: "[new Fixture(fn() => 6100)]")]');
+    $t= $this->declare('{}', '#[Annotated(eval: "new Fixture(fn() => 6100)")]');
     $f= $t->annotation(Annotated::class)->argument(0);
 
     Assert::instance(Fixture::class, $f);
@@ -161,7 +163,7 @@ class AnnotationTest {
 
   #[Test]
   public function with_array_lambda() {
-    $t= $this->declare('{}', '#[Annotated(eval: "[[fn() => 6100]]")]');
+    $t= $this->declare('{}', '#[Annotated(eval: "[fn() => 6100]")]');
     $f= $t->annotation(Annotated::class)->argument(0);
 
     Assert::instance('array', $f);

--- a/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
@@ -76,11 +76,11 @@ class AnnotationTest {
 
   /** @return iterable */
   private function evaluation() {
-    yield ['#[Annotated(eval: "\"Test\"")]', ['Test']];
-    yield ['#[Annotated(eval: \'"Test"\')]', ['Test']];
-    yield ['#[Annotated(eval: "new Fixture()")]', [new Fixture()]];
-    yield ['#[Annotated(eval: "Fixture::\$DEFAULT")]', [Fixture::$DEFAULT]];
-    yield ['#[Annotated(eval: "self::\$member")]', ['Test']];
+    yield ['#[Annotated(eval: "[\"Test\"]")]', ['Test']];
+    yield ['#[Annotated(eval: \'["Test"]\')]', ['Test']];
+    yield ['#[Annotated(eval: "[new Fixture()]")]', [new Fixture()]];
+    yield ['#[Annotated(eval: "[Fixture::\$DEFAULT]")]', [Fixture::$DEFAULT]];
+    yield ['#[Annotated(eval: "[self::\$member]")]', ['Test']];
   }
 
   /** @return iterable */
@@ -134,7 +134,7 @@ class AnnotationTest {
 
   #[Test]
   public function with_function() {
-    $t= $this->declare('{}', '#[Annotated(eval: "function() { return 6100; }")]');
+    $t= $this->declare('{}', '#[Annotated(eval: "[function() { return 6100; }]")]');
     $f= $t->annotation(Annotated::class)->argument(0);
 
     Assert::instance('callable', $f);
@@ -143,7 +143,7 @@ class AnnotationTest {
 
   #[Test, Values([['fn() => 6100', 6100], ['fn() => array(1, array(2))', [1, [2]]], ['fn() => [array(1), array(2)]', [[1], [2]]]])]
   public function with_lambda($code, $expected) {
-    $t= $this->declare('{}', '#[Annotated(eval: "'.$code.'")]');
+    $t= $this->declare('{}', '#[Annotated(eval: "['.$code.']")]');
     $f= $t->annotation(Annotated::class)->argument(0);
 
     Assert::instance('callable', $f);
@@ -152,7 +152,7 @@ class AnnotationTest {
 
   #[Test]
   public function with_nested_lambda() {
-    $t= $this->declare('{}', '#[Annotated(eval: "new Fixture(fn() => 6100)")]');
+    $t= $this->declare('{}', '#[Annotated(eval: "[new Fixture(fn() => 6100)]")]');
     $f= $t->annotation(Annotated::class)->argument(0);
 
     Assert::instance(Fixture::class, $f);
@@ -161,7 +161,7 @@ class AnnotationTest {
 
   #[Test]
   public function with_array_lambda() {
-    $t= $this->declare('{}', '#[Annotated(eval: "[fn() => 6100]")]');
+    $t= $this->declare('{}', '#[Annotated(eval: "[[fn() => 6100]]")]');
     $f= $t->annotation(Annotated::class)->argument(0);
 
     Assert::instance('array', $f);
@@ -258,10 +258,16 @@ class AnnotationTest {
     $t->annotation(Parameterized::class)->newInstance();
   }
 
-  #[Test, Values(eval: '[[Annotated::class], [new XPClass(Annotated::class)]]')]
-  public function is($type) {
+  #[Test]
+  public function is_class() {
     $t= $this->declare('{}', '#[Annotated]');
-    Assert::true($t->annotation(Annotated::class)->is($type));
+    Assert::true($t->annotation(Annotated::class)->is(Annotated::class));
+  }
+
+  #[Test]
+  public function is_type() {
+    $t= $this->declare('{}', '#[Annotated]');
+    Assert::true($t->annotation(Annotated::class)->is(new XPClass(Annotated::class)));
   }
 
   #[Test, Values([[Annotated::class, true], [Fixture::class, false]])]


### PR DESCRIPTION
## Change

Currently, we can only supply one annotation argument via *eval*:

```php
#[Callback(eval: 'fn() => ...')]
class T { }

Reflection::type(T::class)->annotation(Callback::class)->argument(0); // Closure
```

This pull request add support for multiple arguments by passing an array:

```php
#[Callbacks(eval: ['fn() => 1', 'fn() => 2'])]
class T { }

Reflection::type(T::class)->annotation(Callbacks::class)->arguments(); // [Closure#1, Closure#2]
```

It also supports named arguments:

```php
#[Callback(eval: ['function' => 'fn() => ...'])]
class T { }

Reflection::type(T::class)->annotation(Callback::class)->argument('function'); // Closure
```

* * * 
Together with https://github.com/xp-framework/core/pull/324, this is a prerequisite for extracting reflection code as proposed by https://github.com/xp-framework/rfc/issues/338.