### PR TITLE
Make Type, Member and Parameter classes implement the Annotated interface

### DIFF
--- a/src/main/php/lang/reflection/Annotated.class.php
+++ b/src/main/php/lang/reflection/Annotated.class.php
@@ -1,0 +1,11 @@
+<?php namespace lang\reflection;
+
+interface Annotated {
+
+  /** @return lang.reflection.Annotations */
+  public function annotations();
+
+  /** @return ?lang.reflection.Annotation */
+  public function annotation(string $type);
+
+}

--- a/src/main/php/lang/reflection/Member.class.php
+++ b/src/main/php/lang/reflection/Member.class.php
@@ -3,7 +3,7 @@
 use lang\{XPClass, Reflection, Value};
 
 /** Base class for constants, properties and methods */
-abstract class Member implements Value {
+abstract class Member implements Annotated, Value {
   protected $reflect, $annotations;
 
   /**

--- a/src/main/php/lang/reflection/Parameter.class.php
+++ b/src/main/php/lang/reflection/Parameter.class.php
@@ -7,7 +7,7 @@ use lang\{Reflection, Type, IllegalStateException};
  *
  * @test lang.reflection.unittest.MethodsTest
  */
-class Parameter {
+class Parameter implements Annotated {
   private $reflect, $method;
   private $annotations= null;
 

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -8,7 +8,7 @@ use lang\{Reflection, Enum, XPClass, Value, VirtualProperty, IllegalArgumentExce
  *
  * @test lang.reflection.unittest.TypeTest
  */
-class Type implements Value {
+class Type implements Annotated, Value {
   private $reflect;
   private $annotations= null;
 


### PR DESCRIPTION
This way, methods processing annotations can use this as a type.