### PR TITLE
Add Source which encapsulates filename, start and end lines for types and methods

### DIFF
--- a/src/main/php/lang/reflection/Member.class.php
+++ b/src/main/php/lang/reflection/Member.class.php
@@ -18,6 +18,9 @@ abstract class Member implements Annotated, Value {
     $this->annotations= $annotations;
   }
 
+  /** Returns type source */
+  public function source(): Source { return new Source($this->reflect); }
+
   /**
    * Returns context for `Type::resolve()`
    *

--- a/src/main/php/lang/reflection/Routine.class.php
+++ b/src/main/php/lang/reflection/Routine.class.php
@@ -9,6 +9,9 @@ abstract class Routine extends Member {
   /** @return [:var] */
   protected function meta() { return Reflection::meta()->methodAnnotations($this->reflect); }
 
+  /** Returns type source */
+  public function source(): Source { return new Source($this->reflect); }
+
   /**
    * Compiles signature
    *

--- a/src/main/php/lang/reflection/Source.class.php
+++ b/src/main/php/lang/reflection/Source.class.php
@@ -1,0 +1,54 @@
+<?php namespace lang\reflection;
+
+use lang\Value;
+
+/** @test lang.reflection.unittest.SourceTest */
+class Source implements Value {
+  private $reflect;
+
+  /** @param ReflectionClass|ReflectionMethod $reflect */
+  public function __construct($reflect) {
+    $this->reflect= $reflect;
+  }
+
+  /** @return string */
+  public function fileName() { return $this->reflect->getFileName(); }
+
+  /** @return int */
+  public function startLine() { return $this->reflect->getStartLine(); }
+
+  /** @return int */
+  public function endLine() { return $this->reflect->getEndLine(); }
+
+  /** @return string */
+  public function hashCode() {
+    return "S{$this->reflect->getFileName()}:{$this->reflect->getStartLine()}-{$this->reflect->getEndLine()}";
+  }
+
+  /** @return string */
+  public function toString() {
+    return sprintf(
+      '%s(file: %s, lines: %d .. %d)',
+      nameof($this),
+      $this->reflect->getFileName(),
+      $this->reflect->getStartLine(),
+      $this->reflect->getEndLine()
+    );
+  }
+
+  /**
+   * Comparison
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    if ($value instanceof self) {
+      return Objects::compare(
+        [$this->reflect->getFileName(), $this->reflect->getStartLine(), $this->reflect->getEndLine()],
+        [$value->reflect->getFileName(), $value->reflect->getStartLine(), $value->reflect->getEndLine()]
+      );
+    }
+    return 1;
+  }
+}

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -70,6 +70,9 @@ class Type implements Annotated, Value {
     }
   }
 
+  /** Returns type source */
+  public function source(): Source { return new Source($this->reflect); }
+
   /**
    * Returns whether a given value is an instance of this type
    *

--- a/src/test/php/lang/reflection/unittest/SourceTest.class.php
+++ b/src/test/php/lang/reflection/unittest/SourceTest.class.php
@@ -1,0 +1,60 @@
+<?php namespace lang\reflection\unittest;
+
+use io\File;
+use io\streams\LinesIn;
+use lang\{ClassLoader, Reflection};
+use test\{Assert, Before, Test};
+
+class SourceTest {
+  private $start, $end;
+
+  #[Before]
+  public function lines() {
+    $i= 0;
+    foreach (new LinesIn(new File(__FILE__)) as $line) {
+      $i++;
+      if (0 === strncmp($line, 'class ', 5)) $this->start= $i;
+    }
+    $this->end= $i;
+  }
+
+  #[Test]
+  public function this_type_source() {
+    $source= Reflection::type($this)->source();
+
+    Assert::equals(__FILE__, $source->fileName());
+    Assert::equals($this->start, $source->startLine());
+    Assert::equals($this->end, $source->endLine());
+  }
+
+  #[Test]
+  public function anonymous_type_source() {
+    $source= Reflection::type(new class() { })->source();
+    $line= __LINE__ - 1;
+
+    Assert::equals(__FILE__, $source->fileName());
+    Assert::equals($line, $source->startLine());
+    Assert::equals($line, $source->endLine());
+  }
+
+  #[Test]
+  public function defined_type_source() {
+    $type= ClassLoader::defineClass('lang.reflection.unittest.SourceTest_Defined', null, [], []);
+    $source= Reflection::type($type)->source();
+
+    Assert::equals('dyn://lang.reflection.unittest.SourceTest_Defined', $source->fileName());
+    Assert::equals(1, $source->startLine());
+    Assert::equals(1, $source->endLine());
+  }
+
+  #[Test]
+  public function method_source() {
+    $source= Reflection::type($this)->method(__FUNCTION__)->source();
+    $start= __LINE__ - 2;
+    $end= __LINE__ + 5;
+
+    Assert::equals(__FILE__, $source->fileName());
+    Assert::equals($start, $source->startLine());
+    Assert::equals($end, $source->endLine());
+  }
+}


### PR DESCRIPTION
```php
$source= Reflection::type(new class() { })->source();

$source->fileName();  // current file
$source->startLine(); // 1
$source->endLine();   // 1, the anonymous type is declared in one line!
```