### PR TITLE
Remove context from properties, methods, constructors and initializers

### DIFF
--- a/src/main/php/lang/reflection/Initializer.class.php
+++ b/src/main/php/lang/reflection/Initializer.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\reflection;
 
-use ArgumentCountError, Error, ReflectionException, Throwable, TypeError;
+use ArgumentCountError, Error, ReflectionException, ReflectionFunction, Throwable, TypeError;
 use lang\Reflection;
 
 /**
@@ -13,7 +13,7 @@ class Initializer extends Routine implements Instantiation {
   private $class, $function;
 
   static function __static() {
-    self::$NOOP= new \ReflectionFunction(function() { });
+    self::$NOOP= new ReflectionFunction(function() { });
   }
 
   /**
@@ -41,12 +41,11 @@ class Initializer extends Routine implements Instantiation {
    * Creates a new instance of the type this constructor belongs to
    *
    * @param  var[] $args
-   * @param  ?string|?lang.XPClass|?lang.reflection.Type $context
    * @return object
    * @throws lang.reflection.InvocationFailed
    * @throws lang.reflection.CannotInstantiate
    */
-  public function newInstance(array $args= [], $context= null) {
+  public function newInstance(array $args= []) {
     try {
       $instance= $this->class->newInstanceWithoutConstructor();
     } catch (ReflectionException $e) {
@@ -57,13 +56,9 @@ class Initializer extends Routine implements Instantiation {
 
     try {
       $pass= PHP_VERSION_ID < 80000 && $args ? Routine::pass($this->reflect, $args) : $args;
-      $this->function->__invoke($instance, $pass, $context);
+      $this->function->__invoke($instance, $pass);
       return $instance;
-    } catch (ArgumentCountError $e) {
-      throw new CannotInstantiate($this->class, $e);
-    } catch (TypeError $e) {
-      throw new CannotInstantiate($this->class, $e);
-    } catch (ReflectionException $e) {
+    } catch (ReflectionException|ArgumentCountError|TypeError $e) {
       throw new CannotInstantiate($this->class, $e);
     } catch (Throwable $e) {
 

--- a/src/main/php/lang/reflection/Instantiation.class.php
+++ b/src/main/php/lang/reflection/Instantiation.class.php
@@ -7,10 +7,9 @@ interface Instantiation {
    * Creates a new instance of the type this constructor belongs to
    *
    * @param  var[] $args
-   * @param  ?string|?lang.XPClass|?lang.reflection.Type $context
    * @return object
    * @throws lang.reflection.InvocationFailed
    * @throws lang.reflection.CannotInstantiate
    */
-  public function newInstance(array $args= [], $context= null);
+  public function newInstance(array $args= []);
 }

--- a/src/main/php/lang/reflection/Method.class.php
+++ b/src/main/php/lang/reflection/Method.class.php
@@ -44,24 +44,14 @@ class Method extends Routine {
    *
    * @param  ?object $instance
    * @param  var[] $args
-   * @param  ?string|?lang.XPClass|?lang.reflection.Type $context
    * @return var
    * @throws lang.reflection.CannotInvoke if prerequisites to the invocation fail
    * @throws lang.reflection.InvocationFailed if invocation raises an exception
    */
-  public function invoke($instance, $args= [], $context= null) {
-
-    // Only allow invoking non-public methods when given a compatible context
-    if (!$this->reflect->isPublic()) {
-      if ($context && Reflection::type($context)->is($this->reflect->class)) {
-        $this->reflect->setAccessible(true);
-      } else {
-        throw new CannotInvoke($this, new ReflectionException('Trying to invoke non-public method'));
-      }
-    }
-
+  public function invoke(?object $instance, $args= []) {
     try {
       $pass= PHP_VERSION_ID < 80000 && $args ? self::pass($this->reflect, $args) : $args;
+      $this->reflect->setAccessible(true);
       return $this->reflect->invokeArgs($instance, $pass);
     } catch (ReflectionException|ArgumentCountError|TypeError $e) {
       throw new CannotInvoke($this, $e);

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -42,25 +42,17 @@ class Property extends Member {
    * Gets this property's value
    *
    * @param  ?object $instance
-   * @param  ?string|?lang.XPClass|?lang.reflection.Type $context
    * @return var
    * @throws lang.reflection.CannotAccess
    */
-  public function get($instance, $context= null) {
-
-    // Only allow reading non-public properties when given a compatible context
-    if (!$this->reflect->isPublic()) {
-      if ($context && Reflection::of($context)->is($this->reflect->getDeclaringClass()->name)) {
-        $this->reflect->setAccessible(true);
-      } else {
-        throw new CannotAccess($this, new ReflectionException('Trying to read non-public property'));
-      }
-    }
-
+  public function get(?object $instance) {
     try {
+      $this->reflect->setAccessible(true);
       return $this->reflect->getValue($instance);
     } catch (ReflectionException $e) {
       throw new CannotAccess($this, $e);
+    } catch (Throwable $e) {
+      throw new AccessingFailed($this, $e);
     }
   }
 
@@ -69,23 +61,13 @@ class Property extends Member {
    *
    * @param  ?object $instance
    * @param  var $value
-   * @param  ?string|?lang.XPClass|?lang.reflection.Type $context
    * @return var The given value
    * @throws lang.reflection.CannotAccess
    * @throws lang.reflection.AccessFailed if setting raises an exception
    */
-  public function set($instance, $value, $context= null) {
-
-    // Only allow reading non-public properties when given a compatible context
-    if (!$this->reflect->isPublic()) {
-      if ($context && Reflection::of($context)->is($this->reflect->getDeclaringClass()->name)) {
-        $this->reflect->setAccessible(true);
-      } else {
-        throw new CannotAccess($this, new ReflectionException('Trying to write non-public property'));
-      }
-    }
-
+  public function set(?object $instance, $value) {
     try {
+      $this->reflect->setAccessible(true);
       $this->reflect->setValue($instance, $value);
       return $value;
     } catch (ReflectionException $e) {

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -44,6 +44,7 @@ class Property extends Member {
    * @param  ?object $instance
    * @return var
    * @throws lang.reflection.CannotAccess
+   * @throws lang.reflection.AccessingFailed if getting raises an exception
    */
   public function get(?object $instance) {
     try {
@@ -63,7 +64,7 @@ class Property extends Member {
    * @param  var $value
    * @return var The given value
    * @throws lang.reflection.CannotAccess
-   * @throws lang.reflection.AccessFailed if setting raises an exception
+   * @throws lang.reflection.AccessingFailed if setting raises an exception
    */
   public function set(?object $instance, $value) {
     try {

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -162,15 +162,13 @@ class Type implements Annotated, Value {
       return new Initializer($this->reflect);
     } else if ($function instanceof \Closure) {
       $reflect= new ReflectionFunction($function);
-      return new Initializer($this->reflect, $reflect, function($instance, $args, $context) use($function) {
+      return new Initializer($this->reflect, $reflect, function($instance, $args) use($function) {
         return $function->call($instance, ...$args);
       });
     } else if ($this->reflect->hasMethod($function)) {
       $reflect= $this->reflect->getMethod($function);
-      return new Initializer($this->reflect, $reflect, function($instance, $args, $context) use($reflect) {
-        if ($context && !$reflect->isPublic() && Reflection::of($context)->isInstance($instance)) {
-          $reflect->setAccessible(true);
-        }
+      return new Initializer($this->reflect, $reflect, function($instance, $args) use($reflect) {
+        $reflect->setAccessible(true);
         return $reflect->invokeArgs($instance, $args);
       });
     }

--- a/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/InstantiationTest.class.php
@@ -92,12 +92,6 @@ class InstantiationTest {
     $t->newInstance();
   }
 
-  #[Test, Expect(CannotInstantiate::class), Values(['private', 'protected'])]
-  public function constructor_cannot_instantiate_using_non_public_constructor($modifier) {
-    $t= $this->declare('{ '.$modifier.' function __construct() { } }');
-    $t->constructor()->newInstance();
-  }
-
   #[Test, Values(['private', 'protected'])]
   public function instantiate_with_non_public_constructor_in_context($modifier) {
     $t= $this->declare('{
@@ -111,12 +105,6 @@ class InstantiationTest {
   public function instantiate_with_constructor_promotion() {
     $t= $this->declare('{ public function __construct(public $value) { } }');
     Assert::equals($this, $t->constructor()->newInstance([$this])->value);
-  }
-
-  #[Test, Expect(CannotInstantiate::class)]
-  public function cannot_instantiate_with_private_constructor_in_incorrect_context() {
-    $t= $this->declare('{ private function __construct() { } }');
-    $t->constructor()->newInstance([], typeof($this));
   }
 
   #[Test, Expect(CannotInstantiate::class)]


### PR DESCRIPTION
Falling in line with https://wiki.php.net/rfc/make-reflection-setaccessible-no-op, implemented in PHP 8.1