### PR TITLE
Add support for PHP 8.4 property hooks

### DIFF
--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\reflection;
 
-use ReflectionException, ReflectionUnionType, Throwable;
+use ReflectionException, ReflectionProperty, ReflectionUnionType, Throwable;
 use lang\{Reflection, XPClass, Type, VirtualProperty, TypeUnion};
 
 /**
@@ -9,6 +9,11 @@ use lang\{Reflection, XPClass, Type, VirtualProperty, TypeUnion};
  * @test lang.reflection.unittest.PropertiesTest
  */
 class Property extends Member {
+  private static $HOOKS;
+
+  static function __static() {
+    self::$HOOKS= method_exists(ReflectionProperty::class, 'getHooks');
+  }
 
   protected function meta() { return Reflection::meta()->propertyAnnotations($this->reflect); }
 
@@ -18,6 +23,11 @@ class Property extends Member {
    * @return ?string
    */
   public function comment() { return Reflection::meta()->propertyComment($this->reflect); }
+
+  /** Returns whether this property is virtual */
+  public function virtual() {
+    return $this->reflect instanceof VirtualProperty || self::$HOOKS && $this->reflect->isVirtual();
+  }
 
   /** Returns a compound name consisting of `[CLASS]::$[NAME]`  */
   public function compoundName(): string {

--- a/src/test/php/lang/reflection/unittest/PropertyHooksTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PropertyHooksTest.class.php
@@ -1,0 +1,59 @@
+<?php namespace lang\reflection\unittest;
+
+use ReflectionProperty;
+use lang\reflection\AccessingFailed;
+use test\verify\Condition;
+use test\{Assert, Expect, Test};
+
+#[Condition(assert: 'method_exists(ReflectionProperty::class, "getHooks")')]
+class PropertyHooksTest {
+  use TypeDefinition;
+
+  #[Test]
+  public function is_virtual() {
+    $type= $this->declare('{ public string $fixture { get => "test"; } }');
+    Assert::true($type->properties()->named('fixture')->virtual());
+  }
+
+  #[Test]
+  public function get() {
+    $type= $this->declare('{ public string $fixture { get => "test"; } }');
+    $instance= $type->newInstance();
+
+    Assert::equals('test', $type->properties()->named('fixture')->get($instance));
+  }
+
+  #[Test]
+  public function set() {
+    $type= $this->declare('{ public string $fixture { set => ucfirst($value); } }');
+    $instance= $type->newInstance();
+    $type->properties()->named('fixture')->set($instance, 'test');
+
+    Assert::equals('Test', $instance->fixture);
+  }
+
+  #[Test]
+  public function set_with_parameter() {
+    $type= $this->declare('{ public string $fixture { set(string $arg) => ucfirst($arg); } }');
+    $instance= $type->newInstance();
+    $type->properties()->named('fixture')->set($instance, 'test');
+
+    Assert::equals('Test', $instance->fixture);
+  }
+
+  #[Test, Expect(AccessingFailed::class)]
+  public function get_set_only_raises() {
+    $type= $this->declare('{ public string $fixture { set => ucfirst($value); } }');
+    $instance= $type->newInstance();
+
+    $type->properties()->named('fixture')->get($instance);
+  }
+
+  #[Test, Expect(AccessingFailed::class)]
+  public function set_get_only_raises() {
+    $type= $this->declare('{ public string $fixture { get => "test"; } }');
+    $instance= $type->newInstance();
+
+    $type->properties()->named('fixture')->set($instance, 'test');
+  }
+}

--- a/src/test/php/lang/reflection/unittest/VirtualPropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/VirtualPropertiesTest.class.php
@@ -16,11 +16,7 @@ class VirtualPropertiesTest {
       DETAIL_RETURNS   => 'string',
       DETAIL_ARGUMENTS => [Modifiers::IS_PUBLIC | Modifiers::IS_READONLY]
     ];
-
     yield $t;
-    if (PHP_VERSION_ID >= 80100) {
-      yield $this->declare('{ public readonly string $fixture; }');
-    }
   }
 
   #[Test, Values(from: 'fixtures')]
@@ -34,6 +30,11 @@ class VirtualPropertiesTest {
       ['fixture' => 'public readonly'],
       array_map(fn($p) => $p->modifiers()->names(), iterator_to_array($type->properties()))
     );
+  }
+
+  #[Test, Values(from: 'fixtures')]
+  public function is_virtual($type) {
+    Assert::true($type->properties()->named('fixture')->virtual());
   }
 
   #[Test, Values(from: 'fixtures')]


### PR DESCRIPTION
See https://wiki.php.net/rfc/property-hooks

* [x] New `lang.reflection.Property::virtual()` method, including support for `@property-read` and `@property-write` properties vie API docs
* [ ] Get hook methods for a given virtual properties 