### PR TITLE
Add support for asymmetric visibility for properties

### DIFF
--- a/src/main/php/lang/reflection/Modifiers.class.php
+++ b/src/main/php/lang/reflection/Modifiers.class.php
@@ -15,9 +15,9 @@ class Modifiers implements Value {
   const IS_PROTECTED     = MODIFIER_PROTECTED;
   const IS_PRIVATE       = MODIFIER_PRIVATE;
   const IS_READONLY      = MODIFIER_READONLY;
-  const IS_PRIVATE_SET   = 0x0400;
+  const IS_PUBLIC_SET    = 0x0400;
   const IS_PROTECTED_SET = 0x0800;
-  const IS_PUBLIC_SET    = 0x1000;
+  const IS_PRIVATE_SET   = 0x1000;
   const IS_NATIVE        = 0x10000;
 
   private static $names= [
@@ -29,9 +29,9 @@ class Modifiers implements Value {
     'abstract'       => self::IS_ABSTRACT,
     'native'         => self::IS_NATIVE,
     'readonly'       => self::IS_READONLY,
-    'private(set)'   => self::IS_PRIVATE_SET,
-    'protected(set)' => self::IS_PROTECTED_SET,
     'public(set)'    => self::IS_PUBLIC_SET,
+    'protected(set)' => self::IS_PROTECTED_SET,
+    'private(set)'   => self::IS_PRIVATE_SET,
   ];
   private $bits;
 
@@ -117,7 +117,7 @@ class Modifiers implements Value {
   /**
    * Gets whether these modifiers are public in regard to the specified hook
    *
-   * @param  ?string $hook
+   * @param  string $hook
    * @return bool
    * @throws lang.IllegalArgumentException
    */
@@ -132,7 +132,7 @@ class Modifiers implements Value {
   /**
    * Gets whether these modifiers are protected in regard to the specified hook
    *
-   * @param  ?string $hook
+   * @param  string $hook
    * @return bool
    * @throws lang.IllegalArgumentException
    */
@@ -147,7 +147,7 @@ class Modifiers implements Value {
   /**
    * Gets whether these modifiers are private in regard to the specified hook
    *
-   * @param  ?string $hook
+   * @param  string $hook
    * @return bool
    * @throws lang.IllegalArgumentException
    */

--- a/src/main/php/lang/reflection/Modifiers.class.php
+++ b/src/main/php/lang/reflection/Modifiers.class.php
@@ -20,6 +20,9 @@ class Modifiers implements Value {
   const IS_PRIVATE_SET   = 0x1000;
   const IS_NATIVE        = 0x10000;
 
+  const GET_MASK         = 0x0007; // PUBLIC | PROTECTED | PRIVATE
+  const SET_MASK         = 0x1c00; // PUBLIC_SET | PROTECTED_SET | PRIVATE_SET
+
   private static $names= [
     'public'         => self::IS_PUBLIC,
     'protected'      => self::IS_PROTECTED,

--- a/src/main/php/lang/reflection/Modifiers.class.php
+++ b/src/main/php/lang/reflection/Modifiers.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\reflection;
 
-use lang\Value;
+use lang\{Value, IllegalArgumentException};
 
 /**
  * Type and member modifiers
@@ -8,24 +8,30 @@ use lang\Value;
  * @test lang.reflection.unittest.ModifiersTest
  */
 class Modifiers implements Value {
-  const IS_STATIC    = MODIFIER_STATIC;
-  const IS_ABSTRACT  = MODIFIER_ABSTRACT;
-  const IS_FINAL     = MODIFIER_FINAL;
-  const IS_PUBLIC    = MODIFIER_PUBLIC;
-  const IS_PROTECTED = MODIFIER_PROTECTED;
-  const IS_PRIVATE   = MODIFIER_PRIVATE;
-  const IS_READONLY  = 0x0080; // XP 10.13: MODIFIER_READONLY
-  const IS_NATIVE    = 0xF000;
+  const IS_STATIC        = MODIFIER_STATIC;
+  const IS_ABSTRACT      = MODIFIER_ABSTRACT;
+  const IS_FINAL         = MODIFIER_FINAL;
+  const IS_PUBLIC        = MODIFIER_PUBLIC;
+  const IS_PROTECTED     = MODIFIER_PROTECTED;
+  const IS_PRIVATE       = MODIFIER_PRIVATE;
+  const IS_READONLY      = MODIFIER_READONLY;
+  const IS_PRIVATE_SET   = 0x0400;
+  const IS_PROTECTED_SET = 0x0800;
+  const IS_PUBLIC_SET    = 0x1000;
+  const IS_NATIVE        = 0x10000;
 
   private static $names= [
-    'public'    => self::IS_PUBLIC,
-    'protected' => self::IS_PROTECTED,
-    'private'   => self::IS_PRIVATE,
-    'static'    => self::IS_STATIC,
-    'final'     => self::IS_FINAL,
-    'abstract'  => self::IS_ABSTRACT,
-    'native'    => self::IS_NATIVE,
-    'readonly'  => self::IS_READONLY,
+    'public'         => self::IS_PUBLIC,
+    'protected'      => self::IS_PROTECTED,
+    'private'        => self::IS_PRIVATE,
+    'static'         => self::IS_STATIC,
+    'final'          => self::IS_FINAL,
+    'abstract'       => self::IS_ABSTRACT,
+    'native'         => self::IS_NATIVE,
+    'readonly'       => self::IS_READONLY,
+    'private(set)'   => self::IS_PRIVATE_SET,
+    'protected(set)' => self::IS_PROTECTED_SET,
+    'public(set)'    => self::IS_PUBLIC_SET,
   ];
   private $bits;
 
@@ -103,19 +109,55 @@ class Modifiers implements Value {
   public function isFinal() { return 0 !== ($this->bits & self::IS_FINAL); }
 
   /** @return bool */
-  public function isPublic() { return 0 !== ($this->bits & self::IS_PUBLIC); }
-
-  /** @return bool */
-  public function isProtected() { return 0 !== ($this->bits & self::IS_PROTECTED); }
-
-  /** @return bool */
-  public function isPrivate() { return 0 !== ($this->bits & self::IS_PRIVATE); }
-
-  /** @return bool */
   public function isNative() { return 0 !== ($this->bits & self::IS_NATIVE); }
 
   /** @return bool */
   public function isReadonly() { return 0 !== ($this->bits & self::IS_READONLY); }
+
+  /**
+   * Gets whether these modifiers are public in regard to the specified hook
+   *
+   * @param  ?string $hook
+   * @return bool
+   * @throws lang.IllegalArgumentException
+   */
+  public function isPublic($hook= 'get') {
+    switch ($hook) {
+      case 'get': return 0 !== ($this->bits & self::IS_PUBLIC);
+      case 'set': return 0 !== ($this->bits & self::IS_PUBLIC_SET);
+      default: throw new IllegalArgumentException('Unknown hook '.$hook);
+    }
+  }
+
+  /**
+   * Gets whether these modifiers are protected in regard to the specified hook
+   *
+   * @param  ?string $hook
+   * @return bool
+   * @throws lang.IllegalArgumentException
+   */
+  public function isProtected($hook= 'get') {
+    switch ($hook) {
+      case 'get': return 0 !== ($this->bits & self::IS_PROTECTED);
+      case 'set': return 0 !== ($this->bits & self::IS_PROTECTED_SET);
+      default: throw new IllegalArgumentException('Unknown hook '.$hook);
+    }
+  }
+
+  /**
+   * Gets whether these modifiers are private in regard to the specified hook
+   *
+   * @param  ?string $hook
+   * @return bool
+   * @throws lang.IllegalArgumentException
+   */
+  public function isPrivate($hook= 'get') {
+    switch ($hook) {
+      case 'get': return 0 !== ($this->bits & self::IS_PRIVATE);
+      case 'set': return 0 !== ($this->bits & self::IS_PRIVATE_SET);
+      default: throw new IllegalArgumentException('Unknown hook '.$hook);
+    }
+  }
 
   /**
    * Compares a given value to this modifiers instance

--- a/src/main/php/lang/reflection/Modifiers.class.php
+++ b/src/main/php/lang/reflection/Modifiers.class.php
@@ -54,7 +54,7 @@ class Modifiers implements Value {
     }
 
     if ($visibility && 0 === ($this->bits & (self::IS_PROTECTED | self::IS_PRIVATE))) {
-      $this->bits |= self::IS_PUBLIC;
+      $this->bits|= self::IS_PUBLIC;
     }
   }
 
@@ -67,7 +67,7 @@ class Modifiers implements Value {
   private static function parse($names) {
     $bits= 0;
     foreach ($names as $name) {
-      $bits |= self::$names[$name];
+      $bits|= self::$names[$name];
     }
     return $bits;
   }

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -55,8 +55,8 @@ class Property extends Member {
     $bits= $this->reflect->getModifiers();
     switch ($hook) {
       case null: return new Modifiers($bits);
-      case 'get': return new Modifiers($bits & ~0x1c00);
-      case 'set': return new Modifiers($set[$bits & 0x1c00] ?? $bits);
+      case 'get': return new Modifiers(($bits & ~Modifiers::SET_MASK) & Modifiers::GET_MASK);
+      case 'set': return new Modifiers($set[$bits & Modifiers::SET_MASK] ?? $bits & Modifiers::GET_MASK);
       default: throw new IllegalArgumentException('Unknown hook '.$hook);
     }
   }

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -52,7 +52,10 @@ class Property extends Member {
       Modifiers::IS_PRIVATE_SET   => Modifiers::IS_PRIVATE,
     ];
 
+    // Readonly implies protected(set)
     $bits= $this->reflect->getModifiers();
+    $bits & Modifiers::IS_READONLY && $bits|= Modifiers::IS_PROTECTED_SET;
+
     switch ($hook) {
       case null: return new Modifiers($bits);
       case 'get': return new Modifiers(($bits & ~Modifiers::SET_MASK) & Modifiers::GET_MASK);
@@ -117,7 +120,9 @@ class Property extends Member {
       $name= $t->getName();
     }
 
-    return Modifiers::namesOf($this->reflect->getModifiers()).' '.$name.' $'.$this->reflect->getName();
+    $bits= $this->reflect->getModifiers();
+    $bits & Modifiers::IS_READONLY && $bits|= Modifiers::IS_PROTECTED_SET;
+    return Modifiers::namesOf($bits).' '.$name.' $'.$this->reflect->getName();
   }
 
   /**

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\reflection;
 
 use ReflectionException, ReflectionUnionType, Throwable;
-use lang\{Reflection, XPClass, Type, VirtualProperty, TypeUnion};
+use lang\{Reflection, XPClass, Type, VirtualProperty, TypeUnion, IllegalArgumentException};
 
 /**
  * Reflection for a single property
@@ -36,6 +36,29 @@ class Property extends Member {
 
     $t= Type::resolve($this->reflect->getType(), Member::resolve($this->reflect), $api);
     return new Constraint($t ?? Type::$VAR, $present);
+  }
+
+  /**
+   * Gets whether these modifiers are public in regard to the specified hook
+   *
+   * @param  ?string $hook Optionally, filter for specified hook only
+   * @return lang.reflection.Modifiers
+   * @throws lang.IllegalArgumentException
+   */
+  public function modifiers($hook= null) {
+    static $set= [
+      Modifiers::IS_PUBLIC_SET    => Modifiers::IS_PUBLIC,
+      Modifiers::IS_PROTECTED_SET => Modifiers::IS_PROTECTED,
+      Modifiers::IS_PRIVATE_SET   => Modifiers::IS_PRIVATE,
+    ];
+
+    $bits= $this->reflect->getModifiers();
+    switch ($hook) {
+      case null: return new Modifiers($bits);
+      case 'get': return new Modifiers($bits & ~0x1c00);
+      case 'set': return new Modifiers($set[$bits & 0x1c00] ?? $bits);
+      default: throw new IllegalArgumentException('Unknown hook '.$hook);
+    }
   }
 
   /**

--- a/src/test/php/lang/reflection/unittest/ModifiersTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ModifiersTest.class.php
@@ -15,6 +15,9 @@ class ModifiersTest {
     yield [Modifiers::IS_PRIVATE, 'private'];
     yield [Modifiers::IS_NATIVE, 'native'];
     yield [Modifiers::IS_READONLY, 'readonly'];
+    yield [Modifiers::IS_PRIVATE_SET, 'private(set)'];
+    yield [Modifiers::IS_PROTECTED_SET, 'protected(set)'];
+    yield [Modifiers::IS_PUBLIC_SET, 'public(set)'];
     yield [Modifiers::IS_FINAL | Modifiers::IS_PUBLIC, 'public final'];
     yield [Modifiers::IS_ABSTRACT | Modifiers::IS_PUBLIC, 'public abstract'];
     yield [Modifiers::IS_ABSTRACT | Modifiers::IS_PROTECTED, 'protected abstract'];
@@ -81,6 +84,36 @@ class ModifiersTest {
   #[Test, Values([['readonly', true], ['public', false]])]
   public function isReadonly($input, $expected) {
     Assert::equals($expected, (new Modifiers($input))->isReadonly());
+  }
+
+  #[Test, Values([['public(set)', true], ['public', true]])]
+  public function isPublicGet($input, $expected) {
+    Assert::equals($expected, (new Modifiers($input))->isPublic('get'));
+  }
+
+  #[Test, Values([['protected(set)', false], ['protected', true]])]
+  public function isProtectedGet($input, $expected) {
+    Assert::equals($expected, (new Modifiers($input))->isProtected('get'));
+  }
+
+  #[Test, Values([['private(set)', false], ['private', true]])]
+  public function isPrivateGet($input, $expected) {
+    Assert::equals($expected, (new Modifiers($input))->isPrivate('get'));
+  }
+
+  #[Test, Values([['public(set)', true], ['public', false]])]
+  public function isPublicSet($input, $expected) {
+    Assert::equals($expected, (new Modifiers($input))->isPublic('set'));
+  }
+
+  #[Test, Values([['protected(set)', true], ['protected', false]])]
+  public function isProtectedSet($input, $expected) {
+    Assert::equals($expected, (new Modifiers($input))->isProtected('set'));
+  }
+
+  #[Test, Values([['private(set)', true], ['private', false]])]
+  public function isPrivateSet($input, $expected) {
+    Assert::equals($expected, (new Modifiers($input))->isPrivate('set'));
   }
 
   #[Test]

--- a/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace lang\reflection\unittest;
 
+use ReflectionProperty;
 use lang\reflection\{AccessingFailed, CannotAccess, Constraint, Modifiers};
 use lang\{Primitive, Type, TypeIntersection, TypeUnion, XPClass, IllegalArgumentException};
 use test\verify\{Condition, Runtime};
@@ -11,7 +12,7 @@ class PropertiesTest {
   private static $ASYMMETRIC;
 
   static function __static() {
-    self::$ASYMMETRIC= method_exists(\ReflectionProperty::class, 'isPrivateSet');
+    self::$ASYMMETRIC= method_exists(ReflectionProperty::class, 'isPrivateSet');
   }
 
   #[Test]

--- a/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
@@ -1,12 +1,18 @@
 <?php namespace lang\reflection\unittest;
 
 use lang\reflection\{AccessingFailed, CannotAccess, Constraint, Modifiers};
-use lang\{Primitive, Type, TypeIntersection, TypeUnion, XPClass, IllegalStateException};
-use test\verify\Runtime;
+use lang\{Primitive, Type, TypeIntersection, TypeUnion, XPClass, IllegalArgumentException};
+use test\verify\{Condition, Runtime};
 use test\{Action, Assert, Expect, Test, Values};
 
 class PropertiesTest {
   use TypeDefinition;
+
+  private static $ASYMMETRIC;
+
+  static function __static() {
+    self::$ASYMMETRIC= method_exists(\ReflectionProperty::class, 'isPrivateSet');
+  }
 
   #[Test]
   public function name() {
@@ -25,6 +31,27 @@ class PropertiesTest {
       new Modifiers('private'),
       $this->declare('{ private $fixture; }')->property('fixture')->modifiers()
     );
+  }
+
+  #[Test, Values(['public', 'protected', 'private'])]
+  public function get_modifiers($modifier) {
+    Assert::equals(
+      new Modifiers($modifier),
+      $this->declare('{ '.$modifier.' $fixture; }')->property('fixture')->modifiers('get')
+    );
+  }
+
+  #[Test, Values(['public', 'protected', 'private'])]
+  public function set_modifiers($modifier) {
+    Assert::equals(
+      new Modifiers($modifier),
+      $this->declare('{ '.$modifier.' $fixture; }')->property('fixture')->modifiers('set')
+    );
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function modifiers_unknown_hook() {
+    $this->declare('{ private $fixture; }')->property('fixture')->modifiers('@unknown');
   }
 
   #[Test]
@@ -228,12 +255,37 @@ class PropertiesTest {
     }
   }
 
-  #[Test, Runtime(php: '>=8.4')]
-  public function asymmetric_visibility() {
-    $t= $this->declare('{ public private(set) string $fixture; }');
+  #[Test, Condition(assert: 'self::$ASYMMETRIC'), Values(['public protected(set)', 'public private(set)', 'protected private(set)'])]
+  public function asymmetric_visibility($modifiers) {
+    $t= $this->declare('{ '.$modifiers.' int $fixture; }');
     Assert::equals(
-      'public private(set) string $name',
+      $modifiers.' int $fixture',
       $t->property('fixture')->toString()
+    );
+  }
+
+  #[Test, Condition(assert: 'self::$ASYMMETRIC'), Values(['public', 'protected', 'private'])]
+  public function set_implicit_when_same_as_get($modifier) {
+    $t= $this->declare('{ '.$modifier.' '.$modifier.'(set) int $fixture; }');
+    Assert::equals(
+      $modifier.' int $fixture',
+      $t->property('fixture')->toString()
+    );
+  }
+
+  #[Test, Condition(assert: 'self::$ASYMMETRIC'), Values(['public', 'protected', 'private'])]
+  public function asymmetric_get($modifier) {
+    Assert::equals(
+      new Modifiers($modifier),
+      $this->declare('{ '.$modifier.' private(set) int $fixture; }')->property('fixture')->modifiers('get')
+    );
+  }
+
+  #[Test, Condition(assert: 'self::$ASYMMETRIC'), Values(['public', 'protected', 'private'])]
+  public function asymmetric_set($modifier) {
+    Assert::equals(
+      new Modifiers($modifier),
+      $this->declare('{ public '.$modifier.'(set) int $fixture; }')->property('fixture')->modifiers('set')
     );
   }
 }

--- a/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
@@ -227,4 +227,13 @@ class PropertiesTest {
       Assert::equals($t->property('fixture'), $expected->target());
     }
   }
+
+  #[Test, Runtime(php: '>=8.4')]
+  public function asymmetric_visibility() {
+    $t= $this->declare('{ public private(set) string $fixture; }');
+    Assert::equals(
+      'public private(set) string $name',
+      $t->property('fixture')->toString()
+    );
+  }
 }

--- a/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
@@ -49,6 +49,22 @@ class PropertiesTest {
     );
   }
 
+  #[Test]
+  public function get_modifiers_erases_static() {
+    Assert::equals(
+      new Modifiers('public'),
+      $this->declare('{ public static int $fixture; }')->property('fixture')->modifiers('get')
+    );
+  }
+
+  #[Test]
+  public function set_modifiers_erases_static() {
+    Assert::equals(
+      new Modifiers('public'),
+      $this->declare('{ public static int $fixture; }')->property('fixture')->modifiers('set')
+    );
+  }
+
   #[Test, Expect(IllegalArgumentException::class)]
   public function modifiers_unknown_hook() {
     $this->declare('{ private $fixture; }')->property('fixture')->modifiers('@unknown');

--- a/src/test/php/lang/reflection/unittest/VirtualPropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/VirtualPropertiesTest.class.php
@@ -25,13 +25,13 @@ class VirtualPropertiesTest {
 
   #[Test, Values(from: 'fixtures')]
   public function readonly_modifier_shown_in_string_representation($type) {
-    Assert::equals('public readonly string $fixture', $type->property('fixture')->toString());
+    Assert::equals('public readonly protected(set) string $fixture', $type->property('fixture')->toString());
   }
 
   #[Test, Values(from: 'fixtures')]
   public function virtual_property_included_in_list($type) {
     Assert::equals(
-      ['fixture' => 'public readonly'],
+      ['fixture' => 'public readonly protected(set)'],
       array_map(fn($p) => $p->modifiers()->names(), iterator_to_array($type->properties()))
     );
   }


### PR DESCRIPTION
## Example
Given the following:
```php
use lang\Reflection;

class Person {
  public private(set) string $name= 'Test';
}
 
$property= Reflection::type(Person::class)->property('name');
```

The modifiers class includes *private(set)* and *protected(set)* support:
```php
$property->modifiers(); // lang.reflect.Modifiers<public private(set)>
```

The *isPublic()*, *isProtected()* and *isPrivate()* methods optionally support "get" or "set":
```php
$property->modifiers()->isPublic('get');  // true
$property->modifiers()->isPrivate('set'); // true
```

The *modifiers()* method can be used with "get" or "set" to produce views on the respective visibility:
```php
$property->modifiers('get')->isPublic();  // true
$property->modifiers('set')->isPrivate(); // true
```

## Tests

The following configurations have run all unit tests successfully:

* [x] All of PHP 7.4 - current PHP 8.3 on GitHub
* [x] PHP compiled with PR php/php-src#15063 applied (*PHP 8.4.0-dev (cli) (built: Aug 25 2024 09:42:45) (NTS)*)

## See also

* https://wiki.php.net/rfc/asymmetric-visibility-v2 
* https://github.com/xp-framework/compiler/pull/183#issuecomment-2308455485