### PR TITLE
Implement support for final properties

### DIFF
--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -193,7 +193,7 @@ class MetaInformation {
   }
 
   /**
-   * Returns (non-literal) modifiers for a given property
+   * Returns modifiers for a given property, including non-declared
    *
    * @param  \ReflectionProperty $reflect
    * @return int
@@ -202,10 +202,10 @@ class MetaInformation {
     $name= $reflect->getDeclaringClass()->name;
     $c= \xp::$cn[$name] ?? strtr($name, '\\', '.');
     if ($meta= \xp::$meta[$c][0][$reflect->getName()][DETAIL_ARGUMENTS] ?? null) {
-      return (int)$meta[0];
+      return $reflect->getModifiers() | (int)$meta[0];
     } else {
       $tags= $this->tags($reflect);
-      return isset($tags['final']) ? MODIFIER_FINAL : 0;
+      return $reflect->getModifiers() | isset($tags['final']) ? MODIFIER_FINAL : 0;
     }
   }
 

--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -205,7 +205,7 @@ class MetaInformation {
       return (int)$meta[0];
     } else {
       $tags= $this->tags($reflect);
-      return $reflect->getModifiers() | (isset($tags['final']) ? MODIFIER_FINAL : 0);
+      return isset($tags['final']) ? MODIFIER_FINAL : 0;
     }
   }
 

--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -193,6 +193,23 @@ class MetaInformation {
   }
 
   /**
+   * Returns (non-literal) modifiers for a given property
+   *
+   * @param  \ReflectionProperty $reflect
+   * @return int
+   */
+  public function propertyModifiers($reflect) {
+    $name= $reflect->getDeclaringClass()->name;
+    $c= \xp::$cn[$name] ?? strtr($name, '\\', '.');
+    if ($meta= \xp::$meta[$c][0][$reflect->getName()][DETAIL_ARGUMENTS] ?? null) {
+      return (int)$meta[0];
+    } else {
+      $tags= $this->tags($reflect);
+      return $reflect->getModifiers() | (isset($tags['final']) ? MODIFIER_FINAL : 0);
+    }
+  }
+
+  /**
    * Returns annotation map (type => arguments) for a given method
    *
    * @param  \ReflectionMethod $reflect

--- a/src/main/php/lang/meta/MetaInformation.class.php
+++ b/src/main/php/lang/meta/MetaInformation.class.php
@@ -205,7 +205,7 @@ class MetaInformation {
       return $reflect->getModifiers() | (int)$meta[0];
     } else {
       $tags= $this->tags($reflect);
-      return $reflect->getModifiers() | isset($tags['final']) ? MODIFIER_FINAL : 0;
+      return $reflect->getModifiers() | (isset($tags['final']) ? MODIFIER_FINAL : 0);
     }
   }
 

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -53,13 +53,8 @@ class Property extends Member {
     ];
 
     // Readonly implies protected(set)
-    $bits= $this->reflect->getModifiers();
+    $bits= Reflection::meta()->propertyModifiers($this->reflect);
     $bits & Modifiers::IS_READONLY && $bits|= Modifiers::IS_PROTECTED_SET;
-
-    // Final properties cannot be declared in PHP < 8.4, fetch from meta information
-    if (PHP_VERSION_ID <= 80400) {
-      $bits|= Reflection::meta()->propertyModifiers($this->reflect);
-    }
 
     switch ($hook) {
       case null: return new Modifiers($bits);

--- a/src/main/php/lang/reflection/Property.class.php
+++ b/src/main/php/lang/reflection/Property.class.php
@@ -56,6 +56,11 @@ class Property extends Member {
     $bits= $this->reflect->getModifiers();
     $bits & Modifiers::IS_READONLY && $bits|= Modifiers::IS_PROTECTED_SET;
 
+    // Final properties cannot be declared in PHP < 8.4, fetch from meta information
+    if (PHP_VERSION_ID <= 80400) {
+      $bits|= Reflection::meta()->propertyModifiers($this->reflect);
+    }
+
     switch ($hook) {
       case null: return new Modifiers($bits);
       case 'get': return new Modifiers(($bits & ~Modifiers::SET_MASK) & Modifiers::GET_MASK);

--- a/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
+++ b/src/test/php/lang/reflection/unittest/PropertiesTest.class.php
@@ -34,6 +34,22 @@ class PropertiesTest {
     );
   }
 
+  #[Test]
+  public function modifiers_tagged_final() {
+    Assert::equals(
+      new Modifiers(['public', 'final']),
+      $this->declare('{ /** @final */ public $fixture; }')->property('fixture')->modifiers()
+    );
+  }
+
+  #[Test, Runtime(php: '>=8.4')]
+  public function modifiers_declared_final() {
+    Assert::equals(
+      new Modifiers(['public', 'final']),
+      $this->declare('{ public final $fixture; }')->property('fixture')->modifiers()
+    );
+  }
+
   #[Test, Values(['public', 'protected', 'private'])]
   public function get_modifiers($modifier) {
     Assert::equals(


### PR DESCRIPTION
When property hooks were introduced into PHP 8.4, it also added a mechanism for properties to be declared as `final`.

## TODO
* [x] Verify support for declared `final` modifier in PHP 8.4
* [x] Add support for [`@final` apidoc tag](https://docs.phpdoc.org/guide/references/phpdoc/tags/final.html)

## See:
* https://wiki.php.net/rfc/property-hooks
* https://wiki.php.net/rfc/final_promotion
* https://externals.io/message/126926#126952