### PR TITLE
Implement `Package::implementation()` to load implementations of a given type

### DIFF
--- a/src/main/php/lang/reflection/Package.class.php
+++ b/src/main/php/lang/reflection/Package.class.php
@@ -122,6 +122,21 @@ class Package implements Value {
     throw new IllegalArgumentException('Given type '.$type.' is not in package '.$this->name);
   }
 
+  /**
+   * Returns an implementation for a given type
+   *
+   * @param  string|lang.reflection.Type $type
+   * @param  string $name
+   * @return lang.reflection.Type
+   * @throws lang.IllegalArgumentException
+   */
+  public function implementation($type, $name) {
+    $impl= $this->type($name);
+    if ($impl->is($type)) return $impl;
+
+    throw new IllegalArgumentException('Given type '.$impl->name().' is not an implementation of '.$type);
+  }
+
   /** @return string */
   public function hashCode() { return md5($this->name); }
 

--- a/src/test/php/lang/reflection/unittest/fixture/CreateInstruction.class.php
+++ b/src/test/php/lang/reflection/unittest/fixture/CreateInstruction.class.php
@@ -1,0 +1,5 @@
+<?php namespace lang\reflection\unittest\fixture;
+
+class CreateInstruction implements Instruction {
+  
+}

--- a/src/test/php/lang/reflection/unittest/fixture/Instruction.class.php
+++ b/src/test/php/lang/reflection/unittest/fixture/Instruction.class.php
@@ -1,0 +1,5 @@
+<?php namespace lang\reflection\unittest\fixture;
+
+interface Instruction {
+  
+}


### PR DESCRIPTION
Implements #15 

```php
use com\example\instructions\Instruction;
use lang\reflection\Package;

$package= new Package('com.example.instructions');
$impl= $package->implementation(Instruction::class, ucfirst($name).'Instruction');
```