### PR TITLE
Fix mixing named and unnamed parameters in PHP 7

### DIFF
--- a/src/main/php/lang/reflection/Routine.class.php
+++ b/src/main/php/lang/reflection/Routine.class.php
@@ -96,7 +96,9 @@ abstract class Routine extends Member {
   public static function pass($reflect, $args) {
     $pass= [];
     foreach ($reflect->getParameters() as $i => $param) {
-      if (isset($args[$param->name])) {
+      if ($param->isVariadic()) {
+        while ($args) $pass[]= array_shift($args);
+      } else if (isset($args[$param->name])) {
         $pass[]= $args[$param->name];
         unset($args[$param->name]);
       } else if (isset($args[$i])) {

--- a/src/main/php/lang/reflection/Routine.class.php
+++ b/src/main/php/lang/reflection/Routine.class.php
@@ -99,10 +99,10 @@ abstract class Routine extends Member {
       if ($param->isVariadic()) {
         while ($args) $pass[]= array_shift($args);
         break;
-      } else if (isset($args[$param->name])) {
+      } else if (array_key_exists($param->name, $args)) {
         $pass[]= $args[$param->name];
         unset($args[$param->name]);
-      } else if (isset($args[$i])) {
+      } else if (array_key_exists($i, $args)) {
         $pass[]= $args[$i];
         unset($args[$i]);
       } else if ($param->isOptional()) {

--- a/src/main/php/lang/reflection/Routine.class.php
+++ b/src/main/php/lang/reflection/Routine.class.php
@@ -3,7 +3,11 @@
 use Error, ReflectionException, ReflectionUnionType, ReflectionIntersectionType;
 use lang\{Reflection, Type, TypeUnion};
 
-/** Base class for methods and constructors */
+/**
+ * Base class for methods and constructors
+ *
+ * @test  lang.reflection.unittest.ArgumentPassingTest
+ */
 abstract class Routine extends Member {
 
   /** @return [:var] */
@@ -90,23 +94,26 @@ abstract class Routine extends Member {
 
   /** Support named arguments for PHP 7.X */
   public static function pass($reflect, $args) {
-    if (is_string(key($args))) {
-      $pass= [];
-      foreach ($reflect->getParameters() as $param) {
-        if (isset($args[$param->name])) {
-          $pass[]= $args[$param->name];
-        } else if ($param->isOptional()) {
-          $pass[]= $param->getDefaultValue();
-        } else {
-          throw new ReflectionException('Missing parameter $'.$param->name);
-        }
+    $pass= [];
+    foreach ($reflect->getParameters() as $i => $param) {
+      if (isset($args[$param->name])) {
+        $pass[]= $args[$param->name];
         unset($args[$param->name]);
+      } else if (isset($args[$i])) {
+        $pass[]= $args[$i];
+        unset($args[$i]);
+      } else if ($param->isOptional()) {
+        $pass[]= $param->getDefaultValue();
+      } else {
+        throw new ReflectionException('Missing parameter $'.$param->name);
       }
-      if ($args) {
-        throw new Error('Unknown named parameter $'.key($args));
-      }
-      return $pass;
     }
-    return $args;
+
+    // Check for excess named parameters
+    if ($args && is_string($excess= key($args))) {
+      throw new Error('Unknown named parameter $'.$excess);
+    }
+
+    return $pass;
   }
 }

--- a/src/main/php/lang/reflection/Routine.class.php
+++ b/src/main/php/lang/reflection/Routine.class.php
@@ -98,6 +98,7 @@ abstract class Routine extends Member {
     foreach ($reflect->getParameters() as $i => $param) {
       if ($param->isVariadic()) {
         while ($args) $pass[]= array_shift($args);
+        break;
       } else if (isset($args[$param->name])) {
         $pass[]= $args[$param->name];
         unset($args[$param->name]);

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -204,7 +204,7 @@ class Type implements Annotated, Value {
     $constructor= $this->reflect->hasMethod('__construct');
     try {
       if ($constructor) {
-        $pass= PHP_VERSION_ID < 80000 && $args ? Routine::pass($constructor, $args) : $args;
+        $pass= PHP_VERSION_ID < 80000 && $args ? Routine::pass($this->reflect->getMethod('__construct'), $args) : $args;
         return $this->reflect->newInstanceArgs($pass);
       } else {
         return $this->reflect->newInstance();

--- a/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
@@ -273,7 +273,7 @@ class AnnotationTest {
     Assert::instance(Annotated::class, $t->annotation(Annotated::class)->newInstance());
   }
 
-  #[Test, Values(['#[Parameterized(1, 2)]', '#[Parameterized(a: 1, b: 2)]', '#[Parameterized(b: 2, a: 1)]'])]
+  #[Test, Values(['#[Parameterized(1, 2)]', '#[Parameterized(1, b: 2)]', '#[Parameterized(a: 1, b: 2)]', '#[Parameterized(b: 2, a: 1)]'])]
   public function parameterized_instantiation($declaration) {
     $t= $this->declare('{}', $declaration);
     Assert::equals(new Parameterized(1, 2), $t->annotation(Parameterized::class)->newInstance());

--- a/src/test/php/lang/reflection/unittest/ArgumentPassingTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ArgumentPassingTest.class.php
@@ -13,6 +13,12 @@ class ArgumentPassingTest {
     Assert::equals([1, 2], Routine::pass($f, [1, 2]));
   }
 
+  #[Test]
+  public function pass_ordered_null() {
+    $f= new ReflectionFunction(fn($a, $b) => null);
+    Assert::equals([null, 2], Routine::pass($f, [null, 2]));
+  }
+
   #[Test, Expect(class: Error::class, message: 'Missing parameter $a')]
   public function missing() {
     $f= new ReflectionFunction(fn($a, $b) => null);
@@ -29,6 +35,12 @@ class ArgumentPassingTest {
   public function pass_named() {
     $f= new ReflectionFunction(fn($a, $b) => null);
     Assert::equals([1, 2], Routine::pass($f, ['a' => 1, 'b' => 2]));
+  }
+
+  #[Test]
+  public function pass_named_null() {
+    $f= new ReflectionFunction(fn($a, $b) => null);
+    Assert::equals([null, 2], Routine::pass($f, ['a' => null, 'b' => 2]));
   }
 
   #[Test]

--- a/src/test/php/lang/reflection/unittest/ArgumentPassingTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ArgumentPassingTest.class.php
@@ -1,0 +1,75 @@
+<?php namespace lang\reflection\unittest;
+
+use ReflectionFunction;
+use lang\Error;
+use lang\reflection\Routine;
+use test\{Assert, Expect, Test};
+
+class ArgumentPassingTest {
+
+  #[Test]
+  public function pass_ordered() {
+    $f= new ReflectionFunction(fn($a, $b) => null);
+    Assert::equals([1, 2], Routine::pass($f, [1, 2]));
+  }
+
+  #[Test, Expect(class: Error::class, message: 'Missing parameter $a')]
+  public function missing() {
+    $f= new ReflectionFunction(fn($a, $b) => null);
+    Routine::pass($f, []);
+  }
+
+  #[Test, Expect(class: Error::class, message: 'Missing parameter $b')]
+  public function missing_ordered() {
+    $f= new ReflectionFunction(fn($a, $b) => null);
+    Routine::pass($f, [1]);
+  }
+
+  #[Test]
+  public function pass_named() {
+    $f= new ReflectionFunction(fn($a, $b) => null);
+    Assert::equals([1, 2], Routine::pass($f, ['a' => 1, 'b' => 2]));
+  }
+
+  #[Test]
+  public function pass_named_out_of_order() {
+    $f= new ReflectionFunction(fn($a, $b) => null);
+    Assert::equals([1, 2], Routine::pass($f, ['b' => 2, 'a' => 1]));
+  }
+
+  #[Test, Expect(class: Error::class, message: 'Missing parameter $b')]
+  public function missing_named() {
+    $f= new ReflectionFunction(fn($a, $b) => null);
+    Routine::pass($f, ['a' => 1]);
+  }
+
+  #[Test, Expect(class: Error::class, message: 'Unknown named parameter $unknown')]
+  public function unknown_named() {
+    $f= new ReflectionFunction(fn($a, $b) => null);
+    Routine::pass($f, ['a' => 1, 'b' => 2, 'unknown' => null]);
+  }
+
+  #[Test]
+  public function pass_named_and_ordered() {
+    $f= new ReflectionFunction(fn($a, $b) => null);
+    Assert::equals([1, 2], Routine::pass($f, [1, 'b' => 2]));
+  }
+
+  #[Test]
+  public function pass_too_many() {
+    $f= new ReflectionFunction(fn($a, $b) => null);
+    Assert::equals([1, 2], Routine::pass($f, [1, 2, 3]));
+  }
+
+  #[Test]
+  public function pass_optional() {
+    $f= new ReflectionFunction(fn($a, $b= 0) => null);
+    Assert::equals([1, 2], Routine::pass($f, [1, 2]));
+  }
+
+  #[Test]
+  public function pass_without_optional() {
+    $f= new ReflectionFunction(fn($a, $b= 0) => null);
+    Assert::equals([1, 0], Routine::pass($f, [1]));
+  }
+}

--- a/src/test/php/lang/reflection/unittest/ArgumentPassingTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ArgumentPassingTest.class.php
@@ -72,4 +72,16 @@ class ArgumentPassingTest {
     $f= new ReflectionFunction(fn($a, $b= 0) => null);
     Assert::equals([1, 0], Routine::pass($f, [1]));
   }
+
+  #[Test]
+  public function pass_variadic() {
+    $f= new ReflectionFunction(fn(... $a) => null);
+    Assert::equals([1, 2], Routine::pass($f, [1, 2]));
+  }
+
+  #[Test]
+  public function pass_variadic_after() {
+    $f= new ReflectionFunction(fn($a, ... $b) => null);
+    Assert::equals([1, 2, 3], Routine::pass($f, [1, 2, 3]));
+  }
 }

--- a/src/test/php/lang/reflection/unittest/ArgumentPassingTest.class.php
+++ b/src/test/php/lang/reflection/unittest/ArgumentPassingTest.class.php
@@ -49,6 +49,12 @@ class ArgumentPassingTest {
     Assert::equals([1, 2], Routine::pass($f, ['b' => 2, 'a' => 1]));
   }
 
+  #[Test]
+  public function omit_optional() {
+    $f= new ReflectionFunction(fn($a, $b= 0, $c= 0) => null);
+    Assert::equals([1, 0, 2], Routine::pass($f, ['a' => 1, 'c' => 2]));
+  }
+
   #[Test, Expect(class: Error::class, message: 'Missing parameter $b')]
   public function missing_named() {
     $f= new ReflectionFunction(fn($a, $b) => null);


### PR DESCRIPTION
The following code returned *1, 2, 0* instead of the correct *1, 0, 2*:

```php
use lang\Reflection;

class T {
  public static function create($a, $b= 0, $c= 0) {
    return [$a, $b, $c];
  }
}

$t= Reflection::type(T::class)->method('create')->invoke(null, [1, 'c' => 2]);
echo implode(', ',  $t), "\n";
```