### PR TITLE
Fix annotation in trait methods not being picked up correctly

### DIFF
--- a/src/main/php/lang/meta/FromSyntaxTree.class.php
+++ b/src/main/php/lang/meta/FromSyntaxTree.class.php
@@ -37,7 +37,7 @@ class FromSyntaxTree {
   }
 
   /** Returns the syntax tree for a given type using a cache */
-  private function treeOf($reflect, $class, $file) {
+  private function treeOf($class, $file) {
     if (null === ($tree= $this->cache[$file] ?? null)) {
       $this->cache[$file]= $tree= self::$lang->parse(new Tokens(file_get_contents($file), $file))->tree();
       if (sizeof($this->cache) > self::CACHE_SIZE) unset($this->cache[key($this->cache)]);
@@ -147,7 +147,7 @@ class FromSyntaxTree {
   }
 
   public function evaluate($arg, $code) {
-    $tree= $arg instanceof SyntaxTree ? $arg : $this->treeOf($arg, $arg, $arg->getFileName());
+    $tree= $arg instanceof SyntaxTree ? $arg : $this->treeOf($arg, $arg->getFileName());
     $parsed= self::parse($code, $tree->resolver())->tree()->children();
     if (1 === sizeof($parsed)) {
       return $parsed[0]->visit($tree);
@@ -190,7 +190,7 @@ class FromSyntaxTree {
   }
 
   public function imports($reflect) {
-    $resolver= $this->treeOf($reflect, $reflect, $reflect->getFileName())->resolver();
+    $resolver= $this->treeOf($reflect, $reflect->getFileName())->resolver();
     $imports= [];
     foreach ($resolver->imports as $alias => $type) {
       $imports[$alias]= ltrim($type, '\\');
@@ -200,34 +200,34 @@ class FromSyntaxTree {
 
   /** @return iterable */
   public function ofType($reflect) {
-    $tree= $this->treeOf($reflect, $reflect, $reflect->getFileName());
+    $tree= $this->treeOf($reflect, $reflect->getFileName());
     return $this->annotations($tree, $tree->type());      
   }
 
   /** @return iterable */
   public function ofConstant($reflect) {
     $class= $reflect->getDeclaringClass();
-    $tree= $this->treeOf($reflect, $class, $class->getFileName());
+    $tree= $this->treeOf($class, $class->getFileName());
     return $this->annotations($tree, $tree->type()->constant($reflect->name));
   }
 
   /** @return iterable */
   public function ofProperty($reflect) {
     $class= $reflect->getDeclaringClass();
-    $tree= $this->treeOf($reflect, $class, $class->getFileName());
+    $tree= $this->treeOf($class, $class->getFileName());
     return $this->annotations($tree, $tree->type()->property($reflect->name));
   }
 
   /** @return iterable */
   public function ofMethod($reflect) {
-    $tree= $this->treeOf($reflect, $reflect->getDeclaringClass(), $reflect->getFileName());
+    $tree= $this->treeOf($reflect->getDeclaringClass(), $reflect->getFileName());
     return $this->annotations($tree, $tree->type()->method($reflect->name));
   }
 
   /** @return iterable */
   public function ofParameter($method, $reflect) {
     $class= $reflect->getDeclaringClass();
-    $tree= $this->treeOf($reflect, $reflect->getDeclaringClass(), $class->getMethod($method->name)->getFileName());
+    $tree= $this->treeOf($class, $class->getMethod($method->name)->getFileName());
     return $this->annotations($tree, $tree->type()
       ->method($method->name)
       ->signature

--- a/src/main/php/lang/meta/FromSyntaxTree.class.php
+++ b/src/main/php/lang/meta/FromSyntaxTree.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\meta;
 
-use lang\IllegalArgumentException;
 use lang\ast\nodes\{ArrayLiteral, FunctionDeclaration};
 use lang\ast\{Language, Token, Tokens, Visitor, Code};
+use lang\{IllegalArgumentException, IllegalStateException};
 
 /**
  * Parses annotations from AST, using PHP language syntax.
@@ -20,6 +20,14 @@ class FromSyntaxTree {
     self::$lang= Language::named('PHP');
   }
 
+  /** Locates a declared partial of a given class */
+  private function partial($tree, $class) {
+    foreach ($class->getTraitNames() as $declared) {
+      if ($type= $tree->type($declared)) return $type;
+    }
+    throw new IllegalStateException('No part of '.$class->name.' declared in tree');
+  }
+
   /** Locates an anonymous class creation expression */
   private function anonymous($tree, $start, $end) {
     foreach ($tree->children() as $child) {
@@ -29,31 +37,16 @@ class FromSyntaxTree {
   }
 
   /** Returns the syntax tree for a given type using a cache */
-  private function tree($reflect) {
-
-    // Handle generic class names correctly
-    if ($class= \xp::$cn[$reflect->name] ?? null) {
-      $class= substr($class, 0, strcspn($class, '<'));
-    } else {
-      $class= strtr($reflect->name, '\\', '.');
-    }
-
-    if (!isset($this->cache[$class])) {
-      if ($reflect->isAnonymous()) {
-        $tree= self::$lang->parse(new Tokens(file_get_contents($reflect->getFileName()), '<anonymous>'))->tree();
-        $type= $this->anonymous($tree, $reflect->getStartLine(), $reflect->getEndLine())->current()->definition;
-      } else {
-        sscanf(\xp::$cl[$class], '%[^:]://%[^$]', $cl, $argument);
-        $instanceFor= [literal($cl), 'instanceFor'];
-        $tree= self::$lang->parse(new Tokens($instanceFor($argument)->loadClassBytes($class), $class))->tree();
-        $type= $tree->type(strtr($class, '.', '\\'));
-      }
-
-      // Limit cache
-      $this->cache[$class]= new SyntaxTree($tree, $type);
+  private function treeOf($reflect, $class, $file) {
+    if (null === ($tree= $this->cache[$file] ?? null)) {
+      $this->cache[$file]= $tree= self::$lang->parse(new Tokens(file_get_contents($file), $file))->tree();
       if (sizeof($this->cache) > self::CACHE_SIZE) unset($this->cache[key($this->cache)]);
     }
-    return $this->cache[$class];
+
+    return new SyntaxTree($tree, $class->isAnonymous()
+      ? $this->anonymous($tree, $class->getStartLine(), $class->getEndLine())->current()->definition
+      : $tree->type($class->name) ?? $this->partial($tree, $class)
+    );
   }
 
   private function parse($code, $resolver) {
@@ -154,7 +147,7 @@ class FromSyntaxTree {
   }
 
   public function evaluate($arg, $code) {
-    $tree= $arg instanceof SyntaxTree ? $arg : $this->tree($arg);
+    $tree= $arg instanceof SyntaxTree ? $arg : $this->treeOf($arg, $arg, $arg->getFileName());
     $parsed= self::parse($code, $tree->resolver())->tree()->children();
     if (1 === sizeof($parsed)) {
       return $parsed[0]->visit($tree);
@@ -197,7 +190,7 @@ class FromSyntaxTree {
   }
 
   public function imports($reflect) {
-    $resolver= $this->tree($reflect)->resolver();
+    $resolver= $this->treeOf($reflect, $reflect, $reflect->getFileName())->resolver();
     $imports= [];
     foreach ($resolver->imports as $alias => $type) {
       $imports[$alias]= ltrim($type, '\\');
@@ -207,31 +200,34 @@ class FromSyntaxTree {
 
   /** @return iterable */
   public function ofType($reflect) {
-    $tree= $this->tree($reflect);
+    $tree= $this->treeOf($reflect, $reflect, $reflect->getFileName());
     return $this->annotations($tree, $tree->type());      
   }
 
   /** @return iterable */
   public function ofConstant($reflect) {
-    $tree= $this->tree($reflect->getDeclaringClass());
+    $class= $reflect->getDeclaringClass();
+    $tree= $this->treeOf($reflect, $class, $class->getFileName());
     return $this->annotations($tree, $tree->type()->constant($reflect->name));
   }
 
   /** @return iterable */
   public function ofProperty($reflect) {
-    $tree= $this->tree($reflect->getDeclaringClass());
+    $class= $reflect->getDeclaringClass();
+    $tree= $this->treeOf($reflect, $class, $class->getFileName());
     return $this->annotations($tree, $tree->type()->property($reflect->name));
   }
 
   /** @return iterable */
   public function ofMethod($reflect) {
-    $tree= $this->tree($reflect->getDeclaringClass());
+    $tree= $this->treeOf($reflect, $reflect->getDeclaringClass(), $reflect->getFileName());
     return $this->annotations($tree, $tree->type()->method($reflect->name));
   }
 
   /** @return iterable */
   public function ofParameter($method, $reflect) {
-    $tree= $this->tree($method->getDeclaringClass());
+    $class= $reflect->getDeclaringClass();
+    $tree= $this->treeOf($reflect, $reflect->getDeclaringClass(), $class->getMethod($method->name)->getFileName());
     return $this->annotations($tree, $tree->type()
       ->method($method->name)
       ->signature

--- a/src/main/php/lang/meta/FromSyntaxTree.class.php
+++ b/src/main/php/lang/meta/FromSyntaxTree.class.php
@@ -37,7 +37,7 @@ class FromSyntaxTree {
   }
 
   /** Returns the syntax tree for a given type using a cache */
-  private function treeOf($class, $file) {
+  private function tree($class, $file) {
     if (null === ($tree= $this->cache[$file] ?? null)) {
       $this->cache[$file]= $tree= self::$lang->parse(new Tokens(file_get_contents($file), $file))->tree();
       if (sizeof($this->cache) > self::CACHE_SIZE) unset($this->cache[key($this->cache)]);
@@ -147,7 +147,7 @@ class FromSyntaxTree {
   }
 
   public function evaluate($arg, $code) {
-    $tree= $arg instanceof SyntaxTree ? $arg : $this->treeOf($arg, $arg->getFileName());
+    $tree= $arg instanceof SyntaxTree ? $arg : $this->tree($arg, $arg->getFileName());
     $parsed= self::parse($code, $tree->resolver())->tree()->children();
     if (1 === sizeof($parsed)) {
       return $parsed[0]->visit($tree);
@@ -190,7 +190,7 @@ class FromSyntaxTree {
   }
 
   public function imports($reflect) {
-    $resolver= $this->treeOf($reflect, $reflect->getFileName())->resolver();
+    $resolver= $this->tree($reflect, $reflect->getFileName())->resolver();
     $imports= [];
     foreach ($resolver->imports as $alias => $type) {
       $imports[$alias]= ltrim($type, '\\');
@@ -200,34 +200,34 @@ class FromSyntaxTree {
 
   /** @return iterable */
   public function ofType($reflect) {
-    $tree= $this->treeOf($reflect, $reflect->getFileName());
+    $tree= $this->tree($reflect, $reflect->getFileName());
     return $this->annotations($tree, $tree->type());      
   }
 
   /** @return iterable */
   public function ofConstant($reflect) {
     $class= $reflect->getDeclaringClass();
-    $tree= $this->treeOf($class, $class->getFileName());
+    $tree= $this->tree($class, $class->getFileName());
     return $this->annotations($tree, $tree->type()->constant($reflect->name));
   }
 
   /** @return iterable */
   public function ofProperty($reflect) {
     $class= $reflect->getDeclaringClass();
-    $tree= $this->treeOf($class, $class->getFileName());
+    $tree= $this->tree($class, $class->getFileName());
     return $this->annotations($tree, $tree->type()->property($reflect->name));
   }
 
   /** @return iterable */
   public function ofMethod($reflect) {
-    $tree= $this->treeOf($reflect->getDeclaringClass(), $reflect->getFileName());
+    $tree= $this->tree($reflect->getDeclaringClass(), $reflect->getFileName());
     return $this->annotations($tree, $tree->type()->method($reflect->name));
   }
 
   /** @return iterable */
   public function ofParameter($method, $reflect) {
     $class= $reflect->getDeclaringClass();
-    $tree= $this->treeOf($class, $class->getMethod($method->name)->getFileName());
+    $tree= $this->tree($class, $class->getMethod($method->name)->getFileName());
     return $this->annotations($tree, $tree->type()
       ->method($method->name)
       ->signature

--- a/src/main/php/lang/reflection/Type.class.php
+++ b/src/main/php/lang/reflection/Type.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\reflection;
 
-use ArgumentCountError, TypeError, ReflectionClass, ReflectionException, ReflectionFunction, Throwable;
+use ArgumentCountError, TypeError, UnitEnum, ReflectionClass, ReflectionException, ReflectionFunction, Throwable;
 use lang\{Reflection, Enum, XPClass, Value, VirtualProperty, IllegalArgumentException};
 
 /**
@@ -54,7 +54,7 @@ class Type implements Annotated, Value {
       return Kind::$INTERFACE;
     } else if ($this->reflect->isTrait()) {
       return Kind::$TRAIT;
-    } else if ($this->reflect->isSubclassOf(Enum::class) || $this->reflect->isSubclassOf(\UnitEnum::class)) {
+    } else if ($this->reflect->isSubclassOf(Enum::class) || $this->reflect->isSubclassOf(UnitEnum::class)) {
       return Kind::$ENUM;
     } else {
       return Kind::$CLASS;

--- a/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AnnotationTest.class.php
@@ -1,9 +1,10 @@
 <?php namespace lang\reflection\unittest;
 
 use ReflectionFunction;
+use lang\reflection\unittest\fixture\Schemas;
 use lang\reflection\{Annotation, CannotInstantiate, InvocationFailed};
 use lang\{IllegalStateException, Reflection, XPClass};
-use test\{Assert, Expect, Test, Values};
+use test\{Assert, Before, Expect, Test, Values};
 
 class AnnotationTest {
   use TypeDefinition;
@@ -417,5 +418,20 @@ class AnnotationTest {
       [Annotated::class => [], Parameterized::class => [1, 2]],
       $t->annotations()->all($type)
     );
+  }
+
+  #[Test]
+  public function used_from_trait() {
+    $t= Reflection::type(Schemas::class);
+
+    foreach ($t->methods() as $name => $method) {
+      $annotations= [];
+      foreach ($method->annotations() as $type => $annotation) {
+        $annotations[$type]= $annotation->arguments();
+      }
+      $actual[$name]= $annotations;
+    }
+
+    Assert::equals(['fixture' => [Before::class => []], 'dialect' => [Before::class => []]], $actual);
   }
 }

--- a/src/test/php/lang/reflection/unittest/AnonymousClassTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AnonymousClassTest.class.php
@@ -12,18 +12,18 @@ class AnonymousClassTest {
 
   /** @see https://github.com/xp-framework/reflection/issues/33 */
   #[Test]
-  public function annotation() {
-    $type= Reflection::type(new class() {
+  public function annotation_on_new_class() {
+    $type= Reflection::type(new class() implements Runnable {
 
       #[Test]
-      public function fixture() { }
+      public function run() { }
     });
 
-    Assert::equals(Test::class, $type->method('fixture')->annotation(Test::class)->type());
+    Assert::equals(Test::class, $type->method('run')->annotation(Test::class)->type());
   }
 
   #[Test]
-  public function newinstance_string() {
+  public function annotation_on_newinstance_string() {
     $type= Reflection::type(newinstance(Runnable::class, [], '{
 
       #[\test\Test]
@@ -34,7 +34,7 @@ class AnonymousClassTest {
   }
 
   #[Test]
-  public function newinstance_map() {
+  public function annotation_on_newinstance_map() {
     $type= Reflection::type(newinstance(Runnable::class, [], [
 
       '#[\test\Test] run' => function() { }

--- a/src/test/php/lang/reflection/unittest/AnonymousClassTest.class.php
+++ b/src/test/php/lang/reflection/unittest/AnonymousClassTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\reflection\unittest;
 
-use lang\Reflection;
+use lang\{Reflection, Runnable};
 use test\{Assert, Test};
 
 class AnonymousClassTest {
@@ -20,5 +20,26 @@ class AnonymousClassTest {
     });
 
     Assert::equals(Test::class, $type->method('fixture')->annotation(Test::class)->type());
+  }
+
+  #[Test]
+  public function newinstance_string() {
+    $type= Reflection::type(newinstance(Runnable::class, [], '{
+
+      #[\test\Test]
+      public function run() { }
+    }'));
+
+    Assert::equals(Test::class, $type->method('run')->annotation(Test::class)->type());
+  }
+
+  #[Test]
+  public function newinstance_map() {
+    $type= Reflection::type(newinstance(Runnable::class, [], [
+
+      '#[\test\Test] run' => function() { }
+    ]));
+
+    Assert::equals(Test::class, $type->method('run')->annotation(Test::class)->type());
   }
 }

--- a/src/test/php/lang/reflection/unittest/fixture/Schemas.class.php
+++ b/src/test/php/lang/reflection/unittest/fixture/Schemas.class.php
@@ -1,0 +1,12 @@
+<?php namespace lang\reflection\unittest\fixture;
+
+use test\Before;
+
+class Schemas {
+  use WithDialect;
+
+  #[Before]
+  public function fixture() {
+    // TBI
+  }
+}

--- a/src/test/php/lang/reflection/unittest/fixture/WithDialect.class.php
+++ b/src/test/php/lang/reflection/unittest/fixture/WithDialect.class.php
@@ -1,0 +1,11 @@
+<?php namespace lang\reflection\unittest\fixture;
+
+use test\Before;
+
+trait WithDialect {
+
+  #[Before]
+  public function dialect() {
+    // TBI
+  }
+}


### PR DESCRIPTION
**(PHP 7.4 only)**

This stems from the fact that `ReflectionMethod::getDeclaringClass()` will point to class *using* the trait instead of the trait itself. Solved by always using `ReflectionMethod::getFileName()` to locate the correct class.